### PR TITLE
Suppress unsupported sqls and make discard statements flag enabled

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>6.0.10</VersionPrefix>
+    <VersionPrefix>6.0.10-yb-1-beta</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
@@ -9,10 +9,10 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Npgsql.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
 
-    <Copyright>Copyright 2021 © The Npgsql Development Team</Copyright>
-    <Company>Npgsql</Company>
+    <Copyright>Copyright 2024 © The YugabyteDB Development Team</Copyright>
+    <Company>YugabyteDB</Company>
     <PackageLicenseExpression>PostgreSQL</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/npgsql/npgsql</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/yugabyte/npgsql</PackageProjectUrl>
     <PackageIcon>postgresql.png</PackageIcon>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
 
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="3.0.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="3.1.5" />
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.1" />
   </ItemGroup>
 </Project>

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -2176,7 +2176,7 @@ public sealed partial class NpgsqlConnector : IDisposable
     {
         var sb = new StringBuilder("SET SESSION AUTHORIZATION DEFAULT;RESET ALL;");
         _resetWithoutDeallocateResponseCount = 2;
-        if (DatabaseInfo.SupportsCloseAll)
+        if (DatabaseInfo.SupportsCloseAll && Settings.EnableCloseAll)
         {
             sb.Append("CLOSE ALL;");
             _resetWithoutDeallocateResponseCount++;
@@ -2265,7 +2265,8 @@ public sealed partial class NpgsqlConnector : IDisposable
                 {
                     // There are no prepared statements.
                     // We simply send DISCARD ALL which is more efficient than sending the above messages separately
-                    PrependInternalMessage(PregeneratedMessages.DiscardAll, 2);
+                    if (Settings.EnableDiscardAll)
+                        PrependInternalMessage(PregeneratedMessages.DiscardAll, 2);
                 }
             }
 

--- a/src/Npgsql/Internal/NpgsqlConnector.cs
+++ b/src/Npgsql/Internal/NpgsqlConnector.cs
@@ -668,7 +668,7 @@ public sealed partial class NpgsqlConnector : IDisposable
                 reader.NextResult();
                 reader.Read();
             }
-                
+
             _isTransactionReadOnly = reader.GetString(0) != "off";
 
             var clusterState = UpdateClusterState();
@@ -2003,7 +2003,7 @@ public sealed partial class NpgsqlConnector : IDisposable
             lock (CleanupLock) { }
             return reason;
         }
-        
+
         try
         {
             // If we're broken while reading prepended messages
@@ -2072,7 +2072,7 @@ public sealed partial class NpgsqlConnector : IDisposable
             Monitor.Exit(CleanupLock);
         }
     }
-        
+
     void FullCleanup()
     {
         lock (CleanupLock)
@@ -2191,12 +2191,12 @@ public sealed partial class NpgsqlConnector : IDisposable
             sb.Append("SELECT pg_advisory_unlock_all();");
             _resetWithoutDeallocateResponseCount += 2;
         }
-        if (DatabaseInfo.SupportsDiscardSequences)
+        if (DatabaseInfo.SupportsDiscardSequences && Settings.EnableDiscardSequences)
         {
             sb.Append("DISCARD SEQUENCES;");
             _resetWithoutDeallocateResponseCount++;
         }
-        if (DatabaseInfo.SupportsDiscardTemp)
+        if (DatabaseInfo.SupportsDiscardTemp && Settings.EnableDiscardTemp)
         {
             sb.Append("DISCARD TEMP");
             _resetWithoutDeallocateResponseCount++;
@@ -2370,7 +2370,7 @@ public sealed partial class NpgsqlConnector : IDisposable
                 throw IsBroken
                     ? new NpgsqlException("The connection was previously broken because of the following exception", _breakReason)
                     : new NpgsqlException("The connection is closed");
-            }  
+            }
 
             if (!_userLock!.Wait(0))
             {

--- a/src/Npgsql/Npgsql.csproj
+++ b/src/Npgsql/Npgsql.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Authors>Shay Rojansky;Nikita Kazmin;Brar Piening;Yoh Deadfall;;Austin Drenski;Emil Lenngren;Francisco Figueiredo Jr.;Kenji Uno</Authors>
+    <Authors>Sfurti Sarah;Shay Rojansky;Nikita Kazmin;Brar Piening;Yoh Deadfall;;Austin Drenski;Emil Lenngren;Francisco Figueiredo Jr.;Kenji Uno</Authors>
     <Description>Npgsql is the open source .NET data provider for PostgreSQL.</Description>
-    <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql</PackageTags>
+    <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql;yugabyte</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- At this point we target netcoreapp3.1 to avoid taking a dependency on System.Text.Json, which is
          necessary for older TFMs. -->

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1412,6 +1412,44 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     }
     ServerCompatibilityMode _serverCompatibilityMode;
 
+    /// <summary>
+    /// Enables running the discard sequences sql during reset.
+    /// </summary>
+    [Category("Compatibility")]
+    [Description("Enables running the discard sequences sql during reset")]
+    [DisplayName("Enable Discard Sequences")]
+    [DefaultValue(true)]
+    [NpgsqlConnectionStringProperty]
+    public bool EnableDiscardSequences
+    {
+        get => _enablediscardsequences;
+        set
+        {
+            _enablediscardsequences = value;
+            SetValue(nameof(EnableDiscardSequences), value);
+        }
+    }
+    bool _enablediscardsequences;
+
+    /// <summary>
+    /// Enables running the discard sequences sql during reset.
+    /// </summary>
+    [Category("Compatibility")]
+    [Description("Enables running the discard temp sql during reset")]
+    [DisplayName("Enable Discard Temp")]
+    [DefaultValue(true)]
+    [NpgsqlConnectionStringProperty]
+    public bool EnableDiscardTemp
+    {
+        get => _enablediscardtemp;
+        set
+        {
+            _enablediscardtemp = value;
+            SetValue(nameof(EnableDiscardTemp), value);
+        }
+    }
+    bool _enablediscardtemp;
+
     #endregion
 
     #region Properties - Obsolete

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -1450,6 +1450,44 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     }
     bool _enablediscardtemp;
 
+    /// <summary>
+    /// Enables running the discard sequences sql during reset.
+    /// </summary>
+    [Category("Compatibility")]
+    [Description("Enables running the Close All sql during reset")]
+    [DisplayName("Enable Close All")]
+    [DefaultValue(true)]
+    [NpgsqlConnectionStringProperty]
+    public bool EnableCloseAll
+    {
+        get => _enablecloseall;
+        set
+        {
+            _enablecloseall = value;
+            SetValue(nameof(EnableCloseAll), value);
+        }
+    }
+    bool _enablecloseall;
+
+    /// <summary>
+    /// Enables running the discard sequences sql during reset.
+    /// </summary>
+    [Category("Compatibility")]
+    [Description("Enables running the Discard All sql during reset")]
+    [DisplayName("Enable Discard All")]
+    [DefaultValue(true)]
+    [NpgsqlConnectionStringProperty]
+    public bool EnableDiscardAll
+    {
+        get => _enablediscardall;
+        set
+        {
+            _enablediscardall = value;
+            SetValue(nameof(EnableDiscardAll), value);
+        }
+    }
+    bool _enablediscardall;
+
     #endregion
 
     #region Properties - Obsolete

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -61,16 +61,12 @@ class PostgresDatabaseInfo : NpgsqlDatabaseInfo
     /// </summary>
     public bool IsRedshift { get; private set; }
 
-    /// <summary>
-    /// True if the backend is YugabyteDB; otherwise, false.
-    /// </summary>
-    public bool IsYugabyteDB { get; set; }
 
     /// <inheritdoc />
-    public override bool SupportsUnlisten => Version.IsGreaterOrEqual(6, 4) && !IsRedshift && !IsYugabyteDB ;
+    public override bool SupportsUnlisten => false ;
 
     /// <inheritdoc />
-    public override bool SupportsAdvisoryLocks => Version.IsGreaterOrEqual(6, 4) && !IsYugabyteDB ;
+    public override bool SupportsAdvisoryLocks => false ;
 
     /// <summary>
     /// True if the 'pg_enum' table includes the 'enumsortorder' column; otherwise, false.
@@ -107,7 +103,6 @@ class PostgresDatabaseInfo : NpgsqlDatabaseInfo
             intDateTimes == "on";
 
         IsRedshift = conn.Settings.ServerCompatibilityMode == ServerCompatibilityMode.Redshift;
-        IsYugabyteDB = ServerVersion.Contains("YB");
         _types = await LoadBackendTypes(conn, timeout, async);
     }
 
@@ -123,6 +118,7 @@ class PostgresDatabaseInfo : NpgsqlDatabaseInfo
     /// </remarks>
     static string GenerateLoadTypesQuery(bool withRange, bool withMultirange, bool loadTableComposites)
         => $@"
+
 SELECT ns.nspname, t.oid, t.typname, t.typtype, t.typnotnull, t.elemtypoid
 FROM (
     -- Arrays have typtype=b - this subquery identifies them by their typreceive and converts their typtype to a

--- a/src/Npgsql/PostgresDatabaseInfo.cs
+++ b/src/Npgsql/PostgresDatabaseInfo.cs
@@ -61,8 +61,16 @@ class PostgresDatabaseInfo : NpgsqlDatabaseInfo
     /// </summary>
     public bool IsRedshift { get; private set; }
 
+    /// <summary>
+    /// True if the backend is YugabyteDB; otherwise, false.
+    /// </summary>
+    public bool IsYugabyteDB { get; set; }
+
     /// <inheritdoc />
-    public override bool SupportsUnlisten => Version.IsGreaterOrEqual(6, 4) && !IsRedshift;
+    public override bool SupportsUnlisten => Version.IsGreaterOrEqual(6, 4) && !IsRedshift && !IsYugabyteDB ;
+
+    /// <inheritdoc />
+    public override bool SupportsAdvisoryLocks => Version.IsGreaterOrEqual(6, 4) && !IsYugabyteDB ;
 
     /// <summary>
     /// True if the 'pg_enum' table includes the 'enumsortorder' column; otherwise, false.
@@ -99,6 +107,7 @@ class PostgresDatabaseInfo : NpgsqlDatabaseInfo
             intDateTimes == "on";
 
         IsRedshift = conn.Settings.ServerCompatibilityMode == ServerCompatibilityMode.Redshift;
+        IsYugabyteDB = ServerVersion.Contains("YB");
         _types = await LoadBackendTypes(conn, timeout, async);
     }
 

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -1911,3 +1911,7 @@ Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardSequences.get -> bool
 Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardSequences.set -> void
 Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardTemp.get -> bool
 Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardTemp.set -> void
+Npgsql.NpgsqlConnectionStringBuilder.EnableCloseAll.get -> bool
+Npgsql.NpgsqlConnectionStringBuilder.EnableCloseAll.set -> void
+Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardAll.get -> bool
+Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardAll.set -> void

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -1907,3 +1907,7 @@ override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.CanConvertFrom(System.Com
 override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
 override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
 override NpgsqlTypes.NpgsqlRange<T>.RangeTypeConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardSequences.get -> bool
+Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardSequences.set -> void
+Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardTemp.get -> bool
+Npgsql.NpgsqlConnectionStringBuilder.EnableDiscardTemp.set -> void


### PR DESCRIPTION
Changes made:
1. Suppressed the unsupported sqls, `Unlisten *` and `pg_advisory_lock()`, if the database is YugabyteDB.
2. Also added connection parameters: `Enable Discard Temp` and `Enable Discard Sequences`, to enable and disable the execution of `Discard Temp` and `Discard Sequences` respectively.