### PR TITLE
Changed PackageIDs and AssemblyName for Nuget publish

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <!-- Compatibility -->
     <PackageVersion Include="System.Threading.Channels" Version="$(SystemVersion)" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemVersion)" />
-    <PackageVersion Include="System.Text.Json" Version="$(SystemVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(SystemVersion) " />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "8.0.100",
     "rollForward": "latestMajor",
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }

--- a/src/Npgsql.DependencyInjection/Npgsql.DependencyInjection.csproj
+++ b/src/Npgsql.DependencyInjection/Npgsql.DependencyInjection.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <PackageId>YBNpgsql.DependencyInjection</PackageId>
         <Authors>Shay Rojansky</Authors>
+        <AssemblyName>YBNpgsql.DependencyInjection</AssemblyName>
         <!-- DbDataSource was introduced to .NET in net7.0. Before that Npgsql has its own built-in copy. -->
         <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">netstandard2.0;net7.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFrameworks>
-        <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql;di;dependency injection</PackageTags>
+        <PackageTags>npgsql;postgresql;postgres;ado;ado.net;database;sql;di;dependency injection;yugabyte</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
+++ b/src/Npgsql.NetTopologySuite/Npgsql.NetTopologySuite.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <PackageId>YBNpgsql.NetTopologySuite</PackageId>
     <Authors>Shay Rojansky;Yoh Deadfall</Authors>
     <Description>NetTopologySuite plugin for Npgsql, allowing mapping of PostGIS geometry types to NetTopologySuite types.</Description>
-    <PackageTags>npgsql;postgresql;postgres;postgis;spatial;nettopologysuite;nts;ado;ado.net;database;sql</PackageTags>
+    <PackageTags>npgsql;postgresql;postgres;postgis;spatial;nettopologysuite;nts;ado;ado.net;database;sql;yugabyte</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <AssemblyName>YBNpgsql.NetTopologySuite</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TargetFramework Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFramework>
     <NoWarn>$(NoWarn);NU5104</NoWarn>

--- a/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
+++ b/src/Npgsql.NodaTime/Npgsql.NodaTime.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <PackageId>YBNpgsql.NodaTime</PackageId>
     <Authors>Shay Rojansky</Authors>
-    <Description>NodaTime plugin for Npgsql, allowing mapping of PostgreSQL date/time types to NodaTime types.</Description>
-    <PackageTags>npgsql;postgresql;postgres;nodatime;date;time;ado;ado;net;database;sql</PackageTags>
+    <Description>NodaTime plugin for NpgsqlYugabyteDB, allowing mapping of YugabyteDB date/time types to NodaTime types.</Description>
+    <PackageTags>npgsql;postgresql;postgres;nodatime;date;time;ado;ado;net;database;sql;yugabytedb</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <AssemblyName>YBNpgsql.NodaTime</AssemblyName>
     <TargetFrameworks Condition="'$(DeveloperBuild)' != 'True'">netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(DeveloperBuild)' == 'True'">net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);NPG9001</NoWarn> <!-- Converter-related APIs are experimental -->


### PR DESCRIPTION
Changed package names and assembly names for the following extensions:
- Npgsql.NodaTime
- Npgsql.NetTopologySuite
- Npgsql.Dependency Injection
These packages need to be published separately on Nuget for EntityFramework Support with the smart driver. 

Entity framework has its own Nodatime and NetTopologySuite extension, and they create a namespace conflict with the upstream Npgsql.NodaTime and Npgsql.NetTopologySuite. Hence we need to publish our own packages