### PR TITLE
Support for connection load balancing across read-replica cluster nodes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <!-- Compatibility -->
     <PackageVersion Include="System.Threading.Channels" Version="$(SystemVersion)" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemVersion)" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(SystemVersion) " />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -50,20 +50,18 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     /// False = Public IPs
     /// </summary>
     protected bool? UseHostColumn = null;
-    /// <summary>
-    /// TODO
-    /// </summary>
-    protected static int index = 0;
 
     /// <summary>
-    /// Stores a map of pool index to number of connections made to the pool
+    /// Stores a map of pool to number of connections made to the pool for the Primary nodes
     /// Key = Pool
     /// Value = Number of Connections to that pool
     /// </summary>
     protected static Dictionary<NpgsqlDataSource, int> poolToNumConnMapPrimary = new Dictionary<NpgsqlDataSource, int>();
 
     /// <summary>
-    /// TODO
+    /// Stores a map of pool to number of connections for the Read Replica nodes
+    /// Key = Pool
+    /// Value = Number of Connections to that pool
     /// </summary>
     protected static Dictionary<NpgsqlDataSource, int> poolToNumConnMapRR = new Dictionary<NpgsqlDataSource, int>();
 
@@ -89,29 +87,29 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     protected static readonly object lockObject = new object();
 
     /// <summary>
-    /// TODO
+    /// Key of primary placement in the allowedPlacementMap
     /// </summary>
     protected readonly int PRIMARY_PLACEMENTS = 1;
     /// <summary>
-    /// TODO
+    /// Key of first fallback placement in the allowedPlacementMap
     /// </summary>
     protected readonly int FIRST_FALLBACK = 2;
     /// <summary>
-    /// TODO
+    /// Key for placements not mentioned in the Toplology Keys in the allowedPlacementMap
     /// </summary>
     protected readonly int REST_OF_CLUSTER = 11;
     /// <summary>
-    /// TODO
+    /// Maximum value of priority of fallback placements possible
     /// </summary>
     protected readonly int MAX_PREFERENCE_VALUE = 10;
     /// <summary>
-    /// TODO
+    /// list of nodes' public IPs
     /// </summary>
     protected Dictionary<string, string> currentPublicIps = new Dictionary<string, string>();
 
     /// <summary>
     /// Contains a dictionary of private IPs for fallback
-    /// Key = Fallback priority leve
+    /// Key = Fallback priority level
     /// Value = Dictionary (IP , nodeType)
     /// </summary>
     protected ConcurrentDictionary<int, Dictionary<string, string>> fallbackPrivateIPs;
@@ -301,15 +299,12 @@ public class ClusterAwareDataSource: NpgsqlDataSource
         }
         else
         {
+            _connectionLogger.LogWarning("Poolindex not found in pools map");
             return;
         }
         lock (lockObject)
         {
             int currentCount;
-            // if (!poolToNumConnMapPrimary.TryGetValue(currPool, out currentCount))
-            // {
-            //     return;
-            // }
 
             if(poolToNumConnMapPrimary.ContainsKey(currPool))
             {

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -330,7 +330,7 @@ public class ClusterAwareDataSource: NpgsqlDataSource
         {
             int currentCount;
 
-            if(poolToNumConnMapPrimary.ContainsKey(currPool))
+            if (poolToNumConnMapPrimary.ContainsKey(currPool))
             {
                 currentCount = poolToNumConnMapPrimary[currPool];
                 poolToNumConnMapPrimary[currPool] += incDec;

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -238,10 +238,10 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     }
 
     /// <summary>
-    ///
+    /// Returns the connection count of a server
     /// </summary>
     /// <param name="server"></param>
-    public int GetLoad(string server)
+    public static int GetLoad(string server)
     {
         foreach (var pool in poolToNumConnMapPrimary)
         {

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -238,6 +238,32 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     }
 
     /// <summary>
+    ///
+    /// </summary>
+    /// <param name="server"></param>
+    public int GetLoad(string server)
+    {
+        foreach (var pool in poolToNumConnMapPrimary)
+        {
+            Debug.Assert(pool.Key.Settings.Host != null, "pool.Key.Settings.Host != null");
+            if (pool.Key.Settings.Host.Equals(server, StringComparison.OrdinalIgnoreCase))
+            {
+                return pool.Value;
+            }
+        }
+        foreach (var pool in poolToNumConnMapRR)
+        {
+            Debug.Assert(pool.Key.Settings.Host != null, "pool.Key.Settings.Host != null");
+            if (pool.Key.Settings.Host.Equals(server, StringComparison.OrdinalIgnoreCase))
+            {
+                return pool.Value;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
     /// gets the list of hosts
     /// </summary>
     /// <param name="conn"></param>

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -926,7 +926,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
                 }
                 else
                 {
-                    if (_dataSource is ClusterAwareDataSource)// || _dataSource is TopologyAwareDataSource)
+                    if (_dataSource is ClusterAwareDataSource)
                     {
                         _dataSource.Return(connector);
                     }

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -176,9 +176,9 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
             Settings = _dataSource.Settings;  // Great, we already have a pool
             return;
         }
-        
+
         // A pool already corresponds to this version of string but also needs Refresh
-        
+
         if (PoolManager.Pools.TryGetValue(_connectionString, out _dataSource) && _dataSource.NeedsRefresh())
         {
             _dataSource.Refresh();
@@ -216,7 +216,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
             _dataSource = PoolManager.Pools.GetOrAdd(_connectionString, _dataSource);
             return;
         }
-        
+
         if (PoolManager.Pools.TryGetValue(canonical, out _dataSource) && _dataSource.NeedsRefresh())
         {
             _dataSource.Refresh();
@@ -926,7 +926,7 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
                 }
                 else
                 {
-                    if (_dataSource is ClusterAwareDataSource || _dataSource is TopologyAwareDataSource)
+                    if (_dataSource is ClusterAwareDataSource)// || _dataSource is TopologyAwareDataSource)
                     {
                         _dataSource.Return(connector);
                     }

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -996,6 +996,25 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     double _failedHostReconnectDelaySecs;
 
     /// <summary>
+    /// If set to true the connections do not go to the rest of the cluster when all the nodes in region specified by topology keys are down
+    /// </summary>
+    [Category("Failover and load balancing")]
+    [Description("Determines if fallback should be done on rest of the cluster")]
+    [DisplayName("FallBack To Topology Keys Only")]
+    [DefaultValue(false)]
+    [NpgsqlConnectionStringProperty]
+    public bool FallBackToTopologyKeysOnly
+    {
+        get => _fallBackToTopologyKeysOnly;
+        set
+        {
+            _fallBackToTopologyKeysOnly = value;
+            SetValue(nameof(FallBackToTopologyKeysOnly), value);
+        }
+    }
+    bool _fallBackToTopologyKeysOnly;
+
+    /// <summary>
     /// Controls for how long the host's cached state will be considered as valid.
     /// </summary>
     [Category("Failover and load balancing")]

--- a/src/Npgsql/NpgsqlConnectionStringBuilder.cs
+++ b/src/Npgsql/NpgsqlConnectionStringBuilder.cs
@@ -929,7 +929,8 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
     [Description("Enables balancing between multiple hosts by round-robin.")]
     [DisplayName("Load Balance Hosts")]
     [NpgsqlConnectionStringProperty]
-    public bool LoadBalanceHosts
+    [DefaultValue(LoadBalanceHosts.False)]
+    public LoadBalanceHosts LoadBalanceHosts
     {
         get => _loadBalanceHosts;
         set
@@ -938,7 +939,7 @@ public sealed partial class NpgsqlConnectionStringBuilder : DbConnectionStringBu
             SetValue(nameof(LoadBalanceHosts), value);
         }
     }
-    bool _loadBalanceHosts;
+    LoadBalanceHosts _loadBalanceHosts;
 
     /// <summary>
     /// Enables balancing between multiple hosts by round-robin in a specified topology
@@ -1857,6 +1858,41 @@ enum ReplicationMode
     /// Logical replication enabled
     /// </summary>
     Logical
+}
+
+/// <summary>
+///
+/// </summary>
+public enum LoadBalanceHosts
+{
+    /// <summary>
+    ///
+    /// </summary>
+    False,
+    /// <summary>
+    ///
+    /// </summary>
+    OnlyRR,
+    /// <summary>
+    ///
+    /// </summary>
+    OnlyPrimary,
+    /// <summary>
+    ///
+    /// </summary>
+    PreferRR,
+    /// <summary>
+    ///
+    /// </summary>
+    PreferPrimary,
+    /// <summary>
+    ///
+    /// </summary>
+    Any,
+    /// <summary>
+    ///
+    /// </summary>
+    True
 }
 
 #endregion

--- a/src/Npgsql/NpgsqlMultiHostDataSource.cs
+++ b/src/Npgsql/NpgsqlMultiHostDataSource.cs
@@ -305,7 +305,7 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
 
         var exceptions = new List<Exception>();
 
-        var poolIndex = conn.Settings.LoadBalanceHosts ? GetRoundRobinIndex() : 0;
+        var poolIndex = conn.Settings.LoadBalanceHosts == LoadBalanceHosts.True ? GetRoundRobinIndex() : 0;
 
         var timeoutPerHost = timeout.IsSet ? timeout.CheckAndGetTimeLeft() : TimeSpan.Zero;
         var preferredType = GetTargetSessionAttributes(conn);

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -568,12 +568,12 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         var config = PrepareConfiguration();
         var connectionStringBuilder = ConnectionStringBuilder.Clone();
 
-        if (ConnectionStringBuilder.LoadBalanceHosts && ConnectionStringBuilder.TopologyKeys != null)
-        {
-            return new TopologyAwareDataSource(ConnectionStringBuilder, config);
-        }
+        // if (ConnectionStringBuilder.LoadBalanceHosts != LoadBalanceHosts.False && ConnectionStringBuilder.TopologyKeys != null)
+        // {
+        //     return new TopologyAwareDataSource(ConnectionStringBuilder, config);
+        // }
 
-        if (ConnectionStringBuilder.LoadBalanceHosts)
+        if (ConnectionStringBuilder.LoadBalanceHosts != LoadBalanceHosts.False)
         {
             return new ClusterAwareDataSource(ConnectionStringBuilder, config, true);
         }

--- a/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
+++ b/src/Npgsql/NpgsqlSlimDataSourceBuilder.cs
@@ -568,10 +568,10 @@ public sealed class NpgsqlSlimDataSourceBuilder : INpgsqlTypeMapper
         var config = PrepareConfiguration();
         var connectionStringBuilder = ConnectionStringBuilder.Clone();
 
-        // if (ConnectionStringBuilder.LoadBalanceHosts != LoadBalanceHosts.False && ConnectionStringBuilder.TopologyKeys != null)
-        // {
-        //     return new TopologyAwareDataSource(ConnectionStringBuilder, config);
-        // }
+        if (ConnectionStringBuilder.LoadBalanceHosts != LoadBalanceHosts.False && ConnectionStringBuilder.TopologyKeys != null)
+        {
+            return new TopologyAwareDataSource(ConnectionStringBuilder, config);
+        }
 
         if (ConnectionStringBuilder.LoadBalanceHosts != LoadBalanceHosts.False)
         {

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -1962,5 +1962,5 @@ YBNpgsql.NpgsqlConnectionStringBuilder.EnableCloseAll.get -> bool
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableCloseAll.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardAll.get -> bool
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardAll.set -> void
-YBNpgsql.ClusterAwareDataSource.GetLoad(string! server) -> int
+static YBNpgsql.ClusterAwareDataSource.GetLoad(string! server) -> int
 

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -1951,7 +1951,9 @@ YBNpgsql.NpgsqlConnectionStringBuilder.YBServersRefreshInterval.get -> double
 YBNpgsql.NpgsqlConnectionStringBuilder.YBServersRefreshInterval.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.FailedHostReconnectDelaySecs.get -> double
 YBNpgsql.NpgsqlConnectionStringBuilder.FailedHostReconnectDelaySecs.set -> void
-
+YBNpgsql.NpgsqlConnectionStringBuilder.FallBackToTopologyKeysOnly.get -> bool
+YBNpgsql.NpgsqlConnectionStringBuilder.FallBackToTopologyKeysOnly.set -> void
+YBNpgsql.TopologyAwareDataSource
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardSequences.get -> bool
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardSequences.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardTemp.get -> bool

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -1962,4 +1962,5 @@ YBNpgsql.NpgsqlConnectionStringBuilder.EnableCloseAll.get -> bool
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableCloseAll.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardAll.get -> bool
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardAll.set -> void
+YBNpgsql.ClusterAwareDataSource.GetLoad(string! server) -> int
 

--- a/src/Npgsql/PublicAPI.Shipped.txt
+++ b/src/Npgsql/PublicAPI.Shipped.txt
@@ -462,7 +462,15 @@ YBNpgsql.NpgsqlConnectionStringBuilder.KeepAlive.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.KerberosServiceName.get -> string!
 YBNpgsql.NpgsqlConnectionStringBuilder.KerberosServiceName.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.Keys.get -> System.Collections.Generic.ICollection<string!>!
-YBNpgsql.NpgsqlConnectionStringBuilder.LoadBalanceHosts.get -> bool
+YBNpgsql.LoadBalanceHosts
+YBNpgsql.LoadBalanceHosts.OnlyRR = 1 -> YBNpgsql.LoadBalanceHosts
+YBNpgsql.LoadBalanceHosts.False = 0 -> YBNpgsql.LoadBalanceHosts
+YBNpgsql.LoadBalanceHosts.OnlyPrimary = 2 -> YBNpgsql.LoadBalanceHosts
+YBNpgsql.LoadBalanceHosts.PreferRR = 3 -> YBNpgsql.LoadBalanceHosts
+YBNpgsql.LoadBalanceHosts.PreferPrimary = 4 -> YBNpgsql.LoadBalanceHosts
+YBNpgsql.LoadBalanceHosts.Any = 5 -> YBNpgsql.LoadBalanceHosts
+YBNpgsql.LoadBalanceHosts.True = 6 -> YBNpgsql.LoadBalanceHosts
+YBNpgsql.NpgsqlConnectionStringBuilder.LoadBalanceHosts.get -> YBNpgsql.LoadBalanceHosts
 YBNpgsql.NpgsqlConnectionStringBuilder.LoadBalanceHosts.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.LoadTableComposites.get -> bool
 YBNpgsql.NpgsqlConnectionStringBuilder.LoadTableComposites.set -> void
@@ -1943,7 +1951,7 @@ YBNpgsql.NpgsqlConnectionStringBuilder.YBServersRefreshInterval.get -> double
 YBNpgsql.NpgsqlConnectionStringBuilder.YBServersRefreshInterval.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.FailedHostReconnectDelaySecs.get -> double
 YBNpgsql.NpgsqlConnectionStringBuilder.FailedHostReconnectDelaySecs.set -> void
-YBNpgsql.TopologyAwareDataSource
+
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardSequences.get -> bool
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardSequences.set -> void
 YBNpgsql.NpgsqlConnectionStringBuilder.EnableDiscardTemp.get -> bool

--- a/src/Npgsql/TopologyAwareDataSource.cs
+++ b/src/Npgsql/TopologyAwareDataSource.cs
@@ -1,353 +1,353 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Data;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using Microsoft.Extensions.Logging;
-
-namespace YBNpgsql;
-
-/// <summary>
-///
-/// </summary>
-public sealed class TopologyAwareDataSource: ClusterAwareDataSource
-{
-    ConcurrentDictionary<int, HashSet<CloudPlacement>?> allowedPlacements;
-
-    internal TopologyAwareDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfig) : base(settings,dataSourceConfig,false)
-    {
-        allowedPlacements = new ConcurrentDictionary<int, HashSet<CloudPlacement>?>();
-        ParseGeoLocations();
-        _connectionLogger.LogDebug("Allowed Placements: {allowedPlacements}", allowedPlacements);
-        Debug.Assert(initialHosts != null, nameof(initialHosts) + " != null");
-        foreach (var host in initialHosts.ToList())
-        {
-            try
-            {
-                var controlSettings = settings;
-                controlSettings.Host = host.ToString();
-                NpgsqlDataSource control = new UnpooledDataSource(controlSettings, dataSourceConfig);
-                NpgsqlConnection controlConnection = NpgsqlConnection.FromDataSource(control);
-                controlConnection.Open();
-                lock (lockObject)
-                {
-                    _hosts = GetCurrentServers(controlConnection);
-                }
-                CreatePool(_hosts);
-                controlConnection.Close();
-                break;
-            }
-            catch (Exception)
-            {
-                _connectionLogger.LogDebug("Could not connect to host: {host}", host);
-                initialHosts.Remove(host);
-                if (initialHosts.Count == 0)
-                {
-                    _connectionLogger.LogError("Failed to make Control Connection. No suitable host found");
-                    throw;
-                }
-            }
-
-        }
-    }
-
-    void ParseGeoLocations()
-    {
-        var values = settings.TopologyKeys?.Split(',');
-        Debug.Assert(values != null, nameof(values) + " != null");
-        foreach (var value in values)
-        {
-            var v = value.Split(':');
-            if (v.Length > 2 || value.EndsWith(":", StringComparison.Ordinal))
-            {
-                throw new InvalidExpressionException("Invalid value part for property" + settings.TopologyKeys + ":" + value);
-            }
-
-            if (v.Length == 1 )
-            {
-                HashSet<CloudPlacement>? primary = allowedPlacements.GetOrAdd(PRIMARY_PLACEMENTS, k => new HashSet<CloudPlacement>());
-                PopulatePlacementSet(v[0], primary);
-            }
-            else
-            {
-                var pref = Convert.ToInt32(v[1]);
-                if (pref == 1)
-                {
-                    HashSet<CloudPlacement>? primary;
-                    if (!allowedPlacements.TryGetValue(PRIMARY_PLACEMENTS, out primary))
-                    {
-                        primary = new HashSet<CloudPlacement>();
-                        allowedPlacements[PRIMARY_PLACEMENTS] = primary;
-                    }
-                    PopulatePlacementSet(v[0], primary);
-                }
-                else if (pref > 1 && pref <= MAX_PREFERENCE_VALUE)
-                {
-                    HashSet<CloudPlacement>? fallbackPlacements;
-                    if (!allowedPlacements.TryGetValue(pref, out fallbackPlacements))
-                    {
-                        fallbackPlacements = new HashSet<CloudPlacement>();
-                        allowedPlacements[pref] = fallbackPlacements;
-                    }
-                    PopulatePlacementSet(v[0], fallbackPlacements);
-                }
-                else
-                {
-                    throw new InvalidExpressionException("Invalid value part for property" + settings.TopologyKeys + ":" + value);
-                }
-            }
-        }
-    }
-
-    void PopulatePlacementSet(string placements, HashSet<CloudPlacement>? allowedPlacements)
-    {
-        var pStrings = placements.Split(',');
-        foreach (var pl in pStrings)
-        {
-            var placementParts = pl.Split('.');
-            if (placementParts.Length != 3 || placementParts[0].Equals("*") || placementParts[1].Equals("*"))
-            {
-                throw new InvalidExpressionException("Malformed " + settings.TopologyKeys + " property value:" + pl);
-            }
-
-            CloudPlacement cp = new CloudPlacement(placementParts[0], placementParts[1], placementParts[2]);
-
-            allowedPlacements?.Add(cp);
-
-        }
-    }
-
-
-    /// <summary>
-    /// Create a new pool
-    /// </summary>
-    internal new  void CreatePool(List<string> hosts)
-    {
-        lock (lockObject)
-        {
-            _hosts = hosts;
-            foreach(var host in _hosts)
-            {
-                var flag = 0;
-                foreach (var pool in _pools)
-                {
-                    if (host.Equals(pool.Settings.Host, StringComparison.OrdinalIgnoreCase))
-                    {
-                        flag = 1;
-                        break;
-                    }
-                }
-
-                if (flag == 1)
-                    continue;
-                var poolSettings = settings.Clone();
-                poolSettings.Host = host.ToString();
-                _connectionLogger.LogDebug("Adding {host} to connection pool", poolSettings.Host);
-
-                _pools.Add(settings.Pooling
-                    ? new PoolingDataSource(poolSettings, dataSourceConfig)
-                    : new UnpooledDataSource(poolSettings, dataSourceConfig));
-
-                poolToNumConnMap[index] = 0;
-                index++;
-
-            }
-            unreachableHostsIndices.Clear();
-        }
-    }
-
-    new bool HasBetterNodeAvailable(int poolindex)
-    {
-        var chosenHost = _pools[poolindex].Settings.Host;
-        if (chosenHost != null && hostToPriorityMap.ContainsKey(chosenHost)) {
-            var chosenHostPriority = hostToPriorityMap[chosenHost];
-            for (var i = 1; i < chosenHostPriority; i++) {
-                if (hostToPriorityMap.Values.Contains(i)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-    void UpdatePriorityMap(string host, string cloud, string region, string zone)
-    {
-        if (!unreachableHosts.Contains(host))
-        {
-            var priority = getPriority(cloud, region, zone);
-            hostToPriorityMap[host] = priority;
-        }
-    }
-
-    private int getPriority(string cloud, string region, string zone) {
-        CloudPlacement cp = new CloudPlacement(cloud, region, zone);
-        return getKeysByValue(cp);
-    }
-
-    private int getKeysByValue(CloudPlacement cp) {
-        int i;
-        HashSet<CloudPlacement>? placement;
-        for (i = 1; i <= MAX_PREFERENCE_VALUE; i++)
-        {
-            allowedPlacements.TryGetValue(i, out placement);
-            if (placement != null && allowedPlacements.Any()) {
-                if (cp.IsContainedIn(placement)){
-                    return i;
-                }
-            }
-        }
-        return MAX_PREFERENCE_VALUE + 1;
-    }
-
-    new List<string> GetCurrentServers(NpgsqlConnection conn)
-    {
-        NpgsqlCommand QUERY_SERVER = new NpgsqlCommand("Select * from yb_servers()",conn);
-        NpgsqlDataReader reader = QUERY_SERVER.ExecuteReader();
-        _lastServerFetchTime = DateTime.Now;
-        List<string> currentPrivateIps = new List<string>();
-        var hostConnectedTo = conn.Host;
-        hostToPriorityMap.Clear();
-
-        Debug.Assert(hostConnectedTo != null, nameof(hostConnectedTo) + " != null");
-        while (reader.Read())
-        {
-            var host = reader.GetString(reader.GetOrdinal("host"));
-            var publicHost = reader.GetString(reader.GetOrdinal("public_ip"));
-            var cloud = reader.GetString(reader.GetOrdinal("cloud"));
-            var region = reader.GetString(reader.GetOrdinal("region"));
-            var zone = reader.GetString(reader.GetOrdinal("zone"));
-
-            UpdatePriorityMap(host, cloud, region, zone);
-
-            UpdateCurrentHostList(currentPrivateIps, host, publicHost, cloud, region, zone);
-
-            if (hostConnectedTo.Equals(host))
-            {
-                UseHostColumn = true;
-            } else if (hostConnectedTo.Equals(publicHost)) {
-                UseHostColumn = false;
-            }
-
-        }
-        return GetPrivateOrPublicServers(currentPrivateIps, currentPublicIps);
-    }
-
-    new List<string> GetPrivateOrPublicServers(List<string> privateHosts, List<string> publicHosts)
-    {
-        List<string> servers = base.GetPrivateOrPublicServers(privateHosts, publicHosts);
-        var flag = 0;
-
-        if (servers != null && servers.Any())
-        {
-            foreach (var server in servers)
-            {
-                if (!unreachableHosts.Contains(server))
-                {
-                    flag = 1;
-                    break;
-                }
-            }
-
-            if (flag == 1)
-                return servers;
-        }
-
-        for (var i = FIRST_FALLBACK; i <= MAX_PREFERENCE_VALUE; i++)
-        {
-            if (fallbackPrivateIPs[i] != null && !fallbackPrivateIPs[i].Any())
-            {
-                return base.GetPrivateOrPublicServers(fallbackPrivateIPs[i], fallbackPublicIPs[i]);
-            }
-        }
-
-        return base.GetPrivateOrPublicServers(fallbackPrivateIPs[REST_OF_CLUSTER], fallbackPublicIPs[REST_OF_CLUSTER]);
-    }
-
-    void UpdateCurrentHostList(List<string> currentPrivateIPs, string host, string publicIP, string cloud, string region, string zone)
-    {
-        CloudPlacement cp = new CloudPlacement(cloud, region, zone);
-        if (cp.IsContainedIn(allowedPlacements[PRIMARY_PLACEMENTS]))
-        {
-            currentPrivateIPs.Add(host);
-            if (!string.IsNullOrEmpty(publicIP.Trim()))
-            {
-                currentPublicIps.Add(publicIP);
-            }
-        }
-        else
-        {
-            foreach (var allowedCPs in allowedPlacements)
-            {
-                if (cp.IsContainedIn(allowedCPs.Value))
-                {
-                    List<string> hosts = fallbackPrivateIPs.GetOrAdd(allowedCPs.Key, k => new List<string>());
-                    hosts.Add(host);
-
-                    if (!string.IsNullOrEmpty(publicIP.Trim()))
-                    {
-                        List<string> publicIPs = fallbackPublicIPs.GetOrAdd(allowedCPs.Key, k => new List<string>());
-                        publicIPs.Add(publicIP);
-                    }
-
-                    return;
-                }
-            }
-
-            List<string> remainingHosts = fallbackPrivateIPs.GetOrAdd(REST_OF_CLUSTER, k => new List<string>());
-            remainingHosts.Add(host);
-            List<string> remainingPublicIPs = fallbackPublicIPs.GetOrAdd(REST_OF_CLUSTER, k => new List<string>());
-            remainingPublicIPs.Add(publicIP);
-        }
-    }
-
-    class CloudPlacement
-    {
-        private string cloud;
-        private string region;
-        private string zone;
-
-        internal CloudPlacement(string cloud, string region, string zone) {
-            this.cloud = cloud;
-            this.region = region;
-            this.zone = zone;
-        }
-
-        public bool EqualPlacements(CloudPlacement obj)
-        {
-            var equal = false;
-            equal = cloud.Equals(obj.cloud, StringComparison.OrdinalIgnoreCase) &&
-                    region.Equals(obj.region, StringComparison.OrdinalIgnoreCase) &&
-                    zone.Equals(obj.zone, StringComparison.OrdinalIgnoreCase);
-            return equal;
-        }
-
-        public bool IsContainedIn(HashSet<CloudPlacement>? set)
-        {
-            Debug.Assert(set != null, nameof(set) + " != null");
-            foreach (var cp in set)
-            {
-               if (cp.zone.Equals("*"))
-               {
-                   if (cp.cloud.Equals(cloud, StringComparison.OrdinalIgnoreCase) &&
-                       cp.region.Equals(region, StringComparison.OrdinalIgnoreCase))
-                   {
-                       return true;
-                   }
-               }
-               else
-               {
-                   if (cp.cloud.Equals(cloud, StringComparison.OrdinalIgnoreCase) &&
-                       cp.region.Equals(region, StringComparison.OrdinalIgnoreCase) &&
-                       cp.zone.Equals(zone, StringComparison.OrdinalIgnoreCase))
-                   {
-                       return true;
-                   }
-               }
-            }
-
-            return false;
-        }
-    }
-}
+// using System;
+// using System.Collections.Concurrent;
+// using System.Collections.Generic;
+// using System.Collections.Specialized;
+// using System.Data;
+// using System.Diagnostics;
+// using System.Diagnostics.CodeAnalysis;
+// using System.Linq;
+// using Microsoft.Extensions.Logging;
+//
+// namespace YBNpgsql;
+//
+// /// <summary>
+// ///
+// /// </summary>
+// public sealed class TopologyAwareDataSource: ClusterAwareDataSource
+// {
+//     ConcurrentDictionary<int, HashSet<CloudPlacement>?> allowedPlacements;
+//
+//     internal TopologyAwareDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfig) : base(settings,dataSourceConfig,false)
+//     {
+//         allowedPlacements = new ConcurrentDictionary<int, HashSet<CloudPlacement>?>();
+//         ParseGeoLocations();
+//         _connectionLogger.LogDebug("Allowed Placements: {allowedPlacements}", allowedPlacements);
+//         Debug.Assert(initialHosts != null, nameof(initialHosts) + " != null");
+//         foreach (var host in initialHosts.ToList())
+//         {
+//             try
+//             {
+//                 var controlSettings = settings;
+//                 controlSettings.Host = host.ToString();
+//                 NpgsqlDataSource control = new UnpooledDataSource(controlSettings, dataSourceConfig);
+//                 NpgsqlConnection controlConnection = NpgsqlConnection.FromDataSource(control);
+//                 controlConnection.Open();
+//                 lock (lockObject)
+//                 {
+//                     _hosts = GetCurrentServers(controlConnection);
+//                 }
+//                 CreatePool(_hosts);
+//                 controlConnection.Close();
+//                 break;
+//             }
+//             catch (Exception)
+//             {
+//                 _connectionLogger.LogDebug("Could not connect to host: {host}", host);
+//                 initialHosts.Remove(host);
+//                 if (initialHosts.Count == 0)
+//                 {
+//                     _connectionLogger.LogError("Failed to make Control Connection. No suitable host found");
+//                     throw;
+//                 }
+//             }
+//
+//         }
+//     }
+//
+//     void ParseGeoLocations()
+//     {
+//         var values = settings.TopologyKeys?.Split(',');
+//         Debug.Assert(values != null, nameof(values) + " != null");
+//         foreach (var value in values)
+//         {
+//             var v = value.Split(':');
+//             if (v.Length > 2 || value.EndsWith(":", StringComparison.Ordinal))
+//             {
+//                 throw new InvalidExpressionException("Invalid value part for property" + settings.TopologyKeys + ":" + value);
+//             }
+//
+//             if (v.Length == 1 )
+//             {
+//                 HashSet<CloudPlacement>? primary = allowedPlacements.GetOrAdd(PRIMARY_PLACEMENTS, k => new HashSet<CloudPlacement>());
+//                 PopulatePlacementSet(v[0], primary);
+//             }
+//             else
+//             {
+//                 var pref = Convert.ToInt32(v[1]);
+//                 if (pref == 1)
+//                 {
+//                     HashSet<CloudPlacement>? primary;
+//                     if (!allowedPlacements.TryGetValue(PRIMARY_PLACEMENTS, out primary))
+//                     {
+//                         primary = new HashSet<CloudPlacement>();
+//                         allowedPlacements[PRIMARY_PLACEMENTS] = primary;
+//                     }
+//                     PopulatePlacementSet(v[0], primary);
+//                 }
+//                 else if (pref > 1 && pref <= MAX_PREFERENCE_VALUE)
+//                 {
+//                     HashSet<CloudPlacement>? fallbackPlacements;
+//                     if (!allowedPlacements.TryGetValue(pref, out fallbackPlacements))
+//                     {
+//                         fallbackPlacements = new HashSet<CloudPlacement>();
+//                         allowedPlacements[pref] = fallbackPlacements;
+//                     }
+//                     PopulatePlacementSet(v[0], fallbackPlacements);
+//                 }
+//                 else
+//                 {
+//                     throw new InvalidExpressionException("Invalid value part for property" + settings.TopologyKeys + ":" + value);
+//                 }
+//             }
+//         }
+//     }
+//
+//     void PopulatePlacementSet(string placements, HashSet<CloudPlacement>? allowedPlacements)
+//     {
+//         var pStrings = placements.Split(',');
+//         foreach (var pl in pStrings)
+//         {
+//             var placementParts = pl.Split('.');
+//             if (placementParts.Length != 3 || placementParts[0].Equals("*") || placementParts[1].Equals("*"))
+//             {
+//                 throw new InvalidExpressionException("Malformed " + settings.TopologyKeys + " property value:" + pl);
+//             }
+//
+//             CloudPlacement cp = new CloudPlacement(placementParts[0], placementParts[1], placementParts[2]);
+//
+//             allowedPlacements?.Add(cp);
+//
+//         }
+//     }
+//
+//
+//     /// <summary>
+//     /// Create a new pool
+//     /// </summary>
+//     internal new  void CreatePool(List<string> hosts)
+//     {
+//         lock (lockObject)
+//         {
+//             _hosts = hosts;
+//             foreach(var host in _hosts)
+//             {
+//                 var flag = 0;
+//                 foreach (var pool in _pools)
+//                 {
+//                     if (host.Equals(pool.Settings.Host, StringComparison.OrdinalIgnoreCase))
+//                     {
+//                         flag = 1;
+//                         break;
+//                     }
+//                 }
+//
+//                 if (flag == 1)
+//                     continue;
+//                 var poolSettings = settings.Clone();
+//                 poolSettings.Host = host.ToString();
+//                 _connectionLogger.LogDebug("Adding {host} to connection pool", poolSettings.Host);
+//
+//                 _pools.Add(settings.Pooling
+//                     ? new PoolingDataSource(poolSettings, dataSourceConfig)
+//                     : new UnpooledDataSource(poolSettings, dataSourceConfig));
+//
+//                 poolToNumConnMap[index] = 0;
+//                 index++;
+//
+//             }
+//             unreachableHostsIndices.Clear();
+//         }
+//     }
+//
+//     new bool HasBetterNodeAvailable(int poolindex)
+//     {
+//         var chosenHost = _pools[poolindex].Settings.Host;
+//         if (chosenHost != null && hostToPriorityMap.ContainsKey(chosenHost)) {
+//             var chosenHostPriority = hostToPriorityMap[chosenHost];
+//             for (var i = 1; i < chosenHostPriority; i++) {
+//                 if (hostToPriorityMap.Values.Contains(i)) {
+//                     return true;
+//                 }
+//             }
+//         }
+//         return false;
+//     }
+//     void UpdatePriorityMap(string host, string cloud, string region, string zone)
+//     {
+//         if (!unreachableHosts.Contains(host))
+//         {
+//             var priority = getPriority(cloud, region, zone);
+//             hostToPriorityMap[host] = priority;
+//         }
+//     }
+//
+//     private int getPriority(string cloud, string region, string zone) {
+//         CloudPlacement cp = new CloudPlacement(cloud, region, zone);
+//         return getKeysByValue(cp);
+//     }
+//
+//     private int getKeysByValue(CloudPlacement cp) {
+//         int i;
+//         HashSet<CloudPlacement>? placement;
+//         for (i = 1; i <= MAX_PREFERENCE_VALUE; i++)
+//         {
+//             allowedPlacements.TryGetValue(i, out placement);
+//             if (placement != null && allowedPlacements.Any()) {
+//                 if (cp.IsContainedIn(placement)){
+//                     return i;
+//                 }
+//             }
+//         }
+//         return MAX_PREFERENCE_VALUE + 1;
+//     }
+//
+//     new List<string> GetCurrentServers(NpgsqlConnection conn)
+//     {
+//         NpgsqlCommand QUERY_SERVER = new NpgsqlCommand("Select * from yb_servers()",conn);
+//         NpgsqlDataReader reader = QUERY_SERVER.ExecuteReader();
+//         _lastServerFetchTime = DateTime.Now;
+//         List<string> currentPrivateIps = new List<string>();
+//         var hostConnectedTo = conn.Host;
+//         hostToPriorityMap.Clear();
+//
+//         Debug.Assert(hostConnectedTo != null, nameof(hostConnectedTo) + " != null");
+//         while (reader.Read())
+//         {
+//             var host = reader.GetString(reader.GetOrdinal("host"));
+//             var publicHost = reader.GetString(reader.GetOrdinal("public_ip"));
+//             var cloud = reader.GetString(reader.GetOrdinal("cloud"));
+//             var region = reader.GetString(reader.GetOrdinal("region"));
+//             var zone = reader.GetString(reader.GetOrdinal("zone"));
+//
+//             UpdatePriorityMap(host, cloud, region, zone);
+//
+//             UpdateCurrentHostList(currentPrivateIps, host, publicHost, cloud, region, zone);
+//
+//             if (hostConnectedTo.Equals(host))
+//             {
+//                 UseHostColumn = true;
+//             } else if (hostConnectedTo.Equals(publicHost)) {
+//                 UseHostColumn = false;
+//             }
+//
+//         }
+//         return GetPrivateOrPublicServers(currentPrivateIps, currentPublicIps);
+//     }
+//
+//     new List<string> GetPrivateOrPublicServers(List<string> privateHosts, List<string> publicHosts)
+//     {
+//         List<string> servers = base.GetPrivateOrPublicServers(privateHosts, publicHosts);
+//         var flag = 0;
+//
+//         if (servers != null && servers.Any())
+//         {
+//             foreach (var server in servers)
+//             {
+//                 if (!unreachableHosts.Contains(server))
+//                 {
+//                     flag = 1;
+//                     break;
+//                 }
+//             }
+//
+//             if (flag == 1)
+//                 return servers;
+//         }
+//
+//         for (var i = FIRST_FALLBACK; i <= MAX_PREFERENCE_VALUE; i++)
+//         {
+//             if (fallbackPrivateIPs[i] != null && !fallbackPrivateIPs[i].Any())
+//             {
+//                 return base.GetPrivateOrPublicServers(fallbackPrivateIPs[i], fallbackPublicIPs[i]);
+//             }
+//         }
+//
+//         return base.GetPrivateOrPublicServers(fallbackPrivateIPs[REST_OF_CLUSTER], fallbackPublicIPs[REST_OF_CLUSTER]);
+//     }
+//
+//     void UpdateCurrentHostList(List<string> currentPrivateIPs, string host, string publicIP, string cloud, string region, string zone)
+//     {
+//         CloudPlacement cp = new CloudPlacement(cloud, region, zone);
+//         if (cp.IsContainedIn(allowedPlacements[PRIMARY_PLACEMENTS]))
+//         {
+//             currentPrivateIPs.Add(host);
+//             if (!string.IsNullOrEmpty(publicIP.Trim()))
+//             {
+//                 currentPublicIps.Add(publicIP);
+//             }
+//         }
+//         else
+//         {
+//             foreach (var allowedCPs in allowedPlacements)
+//             {
+//                 if (cp.IsContainedIn(allowedCPs.Value))
+//                 {
+//                     List<string> hosts = fallbackPrivateIPs.GetOrAdd(allowedCPs.Key, k => new List<string>());
+//                     hosts.Add(host);
+//
+//                     if (!string.IsNullOrEmpty(publicIP.Trim()))
+//                     {
+//                         List<string> publicIPs = fallbackPublicIPs.GetOrAdd(allowedCPs.Key, k => new List<string>());
+//                         publicIPs.Add(publicIP);
+//                     }
+//
+//                     return;
+//                 }
+//             }
+//
+//             List<string> remainingHosts = fallbackPrivateIPs.GetOrAdd(REST_OF_CLUSTER, k => new List<string>());
+//             remainingHosts.Add(host);
+//             List<string> remainingPublicIPs = fallbackPublicIPs.GetOrAdd(REST_OF_CLUSTER, k => new List<string>());
+//             remainingPublicIPs.Add(publicIP);
+//         }
+//     }
+//
+//     class CloudPlacement
+//     {
+//         private string cloud;
+//         private string region;
+//         private string zone;
+//
+//         internal CloudPlacement(string cloud, string region, string zone) {
+//             this.cloud = cloud;
+//             this.region = region;
+//             this.zone = zone;
+//         }
+//
+//         public bool EqualPlacements(CloudPlacement obj)
+//         {
+//             var equal = false;
+//             equal = cloud.Equals(obj.cloud, StringComparison.OrdinalIgnoreCase) &&
+//                     region.Equals(obj.region, StringComparison.OrdinalIgnoreCase) &&
+//                     zone.Equals(obj.zone, StringComparison.OrdinalIgnoreCase);
+//             return equal;
+//         }
+//
+//         public bool IsContainedIn(HashSet<CloudPlacement>? set)
+//         {
+//             Debug.Assert(set != null, nameof(set) + " != null");
+//             foreach (var cp in set)
+//             {
+//                if (cp.zone.Equals("*"))
+//                {
+//                    if (cp.cloud.Equals(cloud, StringComparison.OrdinalIgnoreCase) &&
+//                        cp.region.Equals(region, StringComparison.OrdinalIgnoreCase))
+//                    {
+//                        return true;
+//                    }
+//                }
+//                else
+//                {
+//                    if (cp.cloud.Equals(cloud, StringComparison.OrdinalIgnoreCase) &&
+//                        cp.region.Equals(region, StringComparison.OrdinalIgnoreCase) &&
+//                        cp.zone.Equals(zone, StringComparison.OrdinalIgnoreCase))
+//                    {
+//                        return true;
+//                    }
+//                }
+//             }
+//
+//             return false;
+//         }
+//     }
+// }

--- a/src/Npgsql/TopologyAwareDataSource.cs
+++ b/src/Npgsql/TopologyAwareDataSource.cs
@@ -1,353 +1,428 @@
-// using System;
-// using System.Collections.Concurrent;
-// using System.Collections.Generic;
-// using System.Collections.Specialized;
-// using System.Data;
-// using System.Diagnostics;
-// using System.Diagnostics.CodeAnalysis;
-// using System.Linq;
-// using Microsoft.Extensions.Logging;
-//
-// namespace YBNpgsql;
-//
-// /// <summary>
-// ///
-// /// </summary>
-// public sealed class TopologyAwareDataSource: ClusterAwareDataSource
-// {
-//     ConcurrentDictionary<int, HashSet<CloudPlacement>?> allowedPlacements;
-//
-//     internal TopologyAwareDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfig) : base(settings,dataSourceConfig,false)
-//     {
-//         allowedPlacements = new ConcurrentDictionary<int, HashSet<CloudPlacement>?>();
-//         ParseGeoLocations();
-//         _connectionLogger.LogDebug("Allowed Placements: {allowedPlacements}", allowedPlacements);
-//         Debug.Assert(initialHosts != null, nameof(initialHosts) + " != null");
-//         foreach (var host in initialHosts.ToList())
-//         {
-//             try
-//             {
-//                 var controlSettings = settings;
-//                 controlSettings.Host = host.ToString();
-//                 NpgsqlDataSource control = new UnpooledDataSource(controlSettings, dataSourceConfig);
-//                 NpgsqlConnection controlConnection = NpgsqlConnection.FromDataSource(control);
-//                 controlConnection.Open();
-//                 lock (lockObject)
-//                 {
-//                     _hosts = GetCurrentServers(controlConnection);
-//                 }
-//                 CreatePool(_hosts);
-//                 controlConnection.Close();
-//                 break;
-//             }
-//             catch (Exception)
-//             {
-//                 _connectionLogger.LogDebug("Could not connect to host: {host}", host);
-//                 initialHosts.Remove(host);
-//                 if (initialHosts.Count == 0)
-//                 {
-//                     _connectionLogger.LogError("Failed to make Control Connection. No suitable host found");
-//                     throw;
-//                 }
-//             }
-//
-//         }
-//     }
-//
-//     void ParseGeoLocations()
-//     {
-//         var values = settings.TopologyKeys?.Split(',');
-//         Debug.Assert(values != null, nameof(values) + " != null");
-//         foreach (var value in values)
-//         {
-//             var v = value.Split(':');
-//             if (v.Length > 2 || value.EndsWith(":", StringComparison.Ordinal))
-//             {
-//                 throw new InvalidExpressionException("Invalid value part for property" + settings.TopologyKeys + ":" + value);
-//             }
-//
-//             if (v.Length == 1 )
-//             {
-//                 HashSet<CloudPlacement>? primary = allowedPlacements.GetOrAdd(PRIMARY_PLACEMENTS, k => new HashSet<CloudPlacement>());
-//                 PopulatePlacementSet(v[0], primary);
-//             }
-//             else
-//             {
-//                 var pref = Convert.ToInt32(v[1]);
-//                 if (pref == 1)
-//                 {
-//                     HashSet<CloudPlacement>? primary;
-//                     if (!allowedPlacements.TryGetValue(PRIMARY_PLACEMENTS, out primary))
-//                     {
-//                         primary = new HashSet<CloudPlacement>();
-//                         allowedPlacements[PRIMARY_PLACEMENTS] = primary;
-//                     }
-//                     PopulatePlacementSet(v[0], primary);
-//                 }
-//                 else if (pref > 1 && pref <= MAX_PREFERENCE_VALUE)
-//                 {
-//                     HashSet<CloudPlacement>? fallbackPlacements;
-//                     if (!allowedPlacements.TryGetValue(pref, out fallbackPlacements))
-//                     {
-//                         fallbackPlacements = new HashSet<CloudPlacement>();
-//                         allowedPlacements[pref] = fallbackPlacements;
-//                     }
-//                     PopulatePlacementSet(v[0], fallbackPlacements);
-//                 }
-//                 else
-//                 {
-//                     throw new InvalidExpressionException("Invalid value part for property" + settings.TopologyKeys + ":" + value);
-//                 }
-//             }
-//         }
-//     }
-//
-//     void PopulatePlacementSet(string placements, HashSet<CloudPlacement>? allowedPlacements)
-//     {
-//         var pStrings = placements.Split(',');
-//         foreach (var pl in pStrings)
-//         {
-//             var placementParts = pl.Split('.');
-//             if (placementParts.Length != 3 || placementParts[0].Equals("*") || placementParts[1].Equals("*"))
-//             {
-//                 throw new InvalidExpressionException("Malformed " + settings.TopologyKeys + " property value:" + pl);
-//             }
-//
-//             CloudPlacement cp = new CloudPlacement(placementParts[0], placementParts[1], placementParts[2]);
-//
-//             allowedPlacements?.Add(cp);
-//
-//         }
-//     }
-//
-//
-//     /// <summary>
-//     /// Create a new pool
-//     /// </summary>
-//     internal new  void CreatePool(List<string> hosts)
-//     {
-//         lock (lockObject)
-//         {
-//             _hosts = hosts;
-//             foreach(var host in _hosts)
-//             {
-//                 var flag = 0;
-//                 foreach (var pool in _pools)
-//                 {
-//                     if (host.Equals(pool.Settings.Host, StringComparison.OrdinalIgnoreCase))
-//                     {
-//                         flag = 1;
-//                         break;
-//                     }
-//                 }
-//
-//                 if (flag == 1)
-//                     continue;
-//                 var poolSettings = settings.Clone();
-//                 poolSettings.Host = host.ToString();
-//                 _connectionLogger.LogDebug("Adding {host} to connection pool", poolSettings.Host);
-//
-//                 _pools.Add(settings.Pooling
-//                     ? new PoolingDataSource(poolSettings, dataSourceConfig)
-//                     : new UnpooledDataSource(poolSettings, dataSourceConfig));
-//
-//                 poolToNumConnMap[index] = 0;
-//                 index++;
-//
-//             }
-//             unreachableHostsIndices.Clear();
-//         }
-//     }
-//
-//     new bool HasBetterNodeAvailable(int poolindex)
-//     {
-//         var chosenHost = _pools[poolindex].Settings.Host;
-//         if (chosenHost != null && hostToPriorityMap.ContainsKey(chosenHost)) {
-//             var chosenHostPriority = hostToPriorityMap[chosenHost];
-//             for (var i = 1; i < chosenHostPriority; i++) {
-//                 if (hostToPriorityMap.Values.Contains(i)) {
-//                     return true;
-//                 }
-//             }
-//         }
-//         return false;
-//     }
-//     void UpdatePriorityMap(string host, string cloud, string region, string zone)
-//     {
-//         if (!unreachableHosts.Contains(host))
-//         {
-//             var priority = getPriority(cloud, region, zone);
-//             hostToPriorityMap[host] = priority;
-//         }
-//     }
-//
-//     private int getPriority(string cloud, string region, string zone) {
-//         CloudPlacement cp = new CloudPlacement(cloud, region, zone);
-//         return getKeysByValue(cp);
-//     }
-//
-//     private int getKeysByValue(CloudPlacement cp) {
-//         int i;
-//         HashSet<CloudPlacement>? placement;
-//         for (i = 1; i <= MAX_PREFERENCE_VALUE; i++)
-//         {
-//             allowedPlacements.TryGetValue(i, out placement);
-//             if (placement != null && allowedPlacements.Any()) {
-//                 if (cp.IsContainedIn(placement)){
-//                     return i;
-//                 }
-//             }
-//         }
-//         return MAX_PREFERENCE_VALUE + 1;
-//     }
-//
-//     new List<string> GetCurrentServers(NpgsqlConnection conn)
-//     {
-//         NpgsqlCommand QUERY_SERVER = new NpgsqlCommand("Select * from yb_servers()",conn);
-//         NpgsqlDataReader reader = QUERY_SERVER.ExecuteReader();
-//         _lastServerFetchTime = DateTime.Now;
-//         List<string> currentPrivateIps = new List<string>();
-//         var hostConnectedTo = conn.Host;
-//         hostToPriorityMap.Clear();
-//
-//         Debug.Assert(hostConnectedTo != null, nameof(hostConnectedTo) + " != null");
-//         while (reader.Read())
-//         {
-//             var host = reader.GetString(reader.GetOrdinal("host"));
-//             var publicHost = reader.GetString(reader.GetOrdinal("public_ip"));
-//             var cloud = reader.GetString(reader.GetOrdinal("cloud"));
-//             var region = reader.GetString(reader.GetOrdinal("region"));
-//             var zone = reader.GetString(reader.GetOrdinal("zone"));
-//
-//             UpdatePriorityMap(host, cloud, region, zone);
-//
-//             UpdateCurrentHostList(currentPrivateIps, host, publicHost, cloud, region, zone);
-//
-//             if (hostConnectedTo.Equals(host))
-//             {
-//                 UseHostColumn = true;
-//             } else if (hostConnectedTo.Equals(publicHost)) {
-//                 UseHostColumn = false;
-//             }
-//
-//         }
-//         return GetPrivateOrPublicServers(currentPrivateIps, currentPublicIps);
-//     }
-//
-//     new List<string> GetPrivateOrPublicServers(List<string> privateHosts, List<string> publicHosts)
-//     {
-//         List<string> servers = base.GetPrivateOrPublicServers(privateHosts, publicHosts);
-//         var flag = 0;
-//
-//         if (servers != null && servers.Any())
-//         {
-//             foreach (var server in servers)
-//             {
-//                 if (!unreachableHosts.Contains(server))
-//                 {
-//                     flag = 1;
-//                     break;
-//                 }
-//             }
-//
-//             if (flag == 1)
-//                 return servers;
-//         }
-//
-//         for (var i = FIRST_FALLBACK; i <= MAX_PREFERENCE_VALUE; i++)
-//         {
-//             if (fallbackPrivateIPs[i] != null && !fallbackPrivateIPs[i].Any())
-//             {
-//                 return base.GetPrivateOrPublicServers(fallbackPrivateIPs[i], fallbackPublicIPs[i]);
-//             }
-//         }
-//
-//         return base.GetPrivateOrPublicServers(fallbackPrivateIPs[REST_OF_CLUSTER], fallbackPublicIPs[REST_OF_CLUSTER]);
-//     }
-//
-//     void UpdateCurrentHostList(List<string> currentPrivateIPs, string host, string publicIP, string cloud, string region, string zone)
-//     {
-//         CloudPlacement cp = new CloudPlacement(cloud, region, zone);
-//         if (cp.IsContainedIn(allowedPlacements[PRIMARY_PLACEMENTS]))
-//         {
-//             currentPrivateIPs.Add(host);
-//             if (!string.IsNullOrEmpty(publicIP.Trim()))
-//             {
-//                 currentPublicIps.Add(publicIP);
-//             }
-//         }
-//         else
-//         {
-//             foreach (var allowedCPs in allowedPlacements)
-//             {
-//                 if (cp.IsContainedIn(allowedCPs.Value))
-//                 {
-//                     List<string> hosts = fallbackPrivateIPs.GetOrAdd(allowedCPs.Key, k => new List<string>());
-//                     hosts.Add(host);
-//
-//                     if (!string.IsNullOrEmpty(publicIP.Trim()))
-//                     {
-//                         List<string> publicIPs = fallbackPublicIPs.GetOrAdd(allowedCPs.Key, k => new List<string>());
-//                         publicIPs.Add(publicIP);
-//                     }
-//
-//                     return;
-//                 }
-//             }
-//
-//             List<string> remainingHosts = fallbackPrivateIPs.GetOrAdd(REST_OF_CLUSTER, k => new List<string>());
-//             remainingHosts.Add(host);
-//             List<string> remainingPublicIPs = fallbackPublicIPs.GetOrAdd(REST_OF_CLUSTER, k => new List<string>());
-//             remainingPublicIPs.Add(publicIP);
-//         }
-//     }
-//
-//     class CloudPlacement
-//     {
-//         private string cloud;
-//         private string region;
-//         private string zone;
-//
-//         internal CloudPlacement(string cloud, string region, string zone) {
-//             this.cloud = cloud;
-//             this.region = region;
-//             this.zone = zone;
-//         }
-//
-//         public bool EqualPlacements(CloudPlacement obj)
-//         {
-//             var equal = false;
-//             equal = cloud.Equals(obj.cloud, StringComparison.OrdinalIgnoreCase) &&
-//                     region.Equals(obj.region, StringComparison.OrdinalIgnoreCase) &&
-//                     zone.Equals(obj.zone, StringComparison.OrdinalIgnoreCase);
-//             return equal;
-//         }
-//
-//         public bool IsContainedIn(HashSet<CloudPlacement>? set)
-//         {
-//             Debug.Assert(set != null, nameof(set) + " != null");
-//             foreach (var cp in set)
-//             {
-//                if (cp.zone.Equals("*"))
-//                {
-//                    if (cp.cloud.Equals(cloud, StringComparison.OrdinalIgnoreCase) &&
-//                        cp.region.Equals(region, StringComparison.OrdinalIgnoreCase))
-//                    {
-//                        return true;
-//                    }
-//                }
-//                else
-//                {
-//                    if (cp.cloud.Equals(cloud, StringComparison.OrdinalIgnoreCase) &&
-//                        cp.region.Equals(region, StringComparison.OrdinalIgnoreCase) &&
-//                        cp.zone.Equals(zone, StringComparison.OrdinalIgnoreCase))
-//                    {
-//                        return true;
-//                    }
-//                }
-//             }
-//
-//             return false;
-//         }
-//     }
-// }
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Data;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace YBNpgsql;
+
+/// <summary>
+///
+/// </summary>
+public sealed class TopologyAwareDataSource: ClusterAwareDataSource
+{
+    ConcurrentDictionary<int, HashSet<CloudPlacement>?> allowedPlacements;
+    Dictionary<string, string> AllRRIps = new Dictionary<string, string>();
+    Dictionary<string, string> AllPrimaryIps = new Dictionary<string, string>();
+
+    internal TopologyAwareDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfig) : base(settings,dataSourceConfig,false)
+    {
+        allowedPlacements = new ConcurrentDictionary<int, HashSet<CloudPlacement>?>();
+        ParseGeoLocations();
+        _connectionLogger.LogDebug("Allowed Placements: {allowedPlacements}", allowedPlacements);
+        Debug.Assert(initialHosts != null, nameof(initialHosts) + " != null");
+        foreach (var host in initialHosts.ToList())
+        {
+            try
+            {
+                var controlSettings = settings;
+                controlSettings.Host = host.ToString();
+                NpgsqlDataSource control = new UnpooledDataSource(controlSettings, dataSourceConfig);
+                NpgsqlConnection controlConnection = NpgsqlConnection.FromDataSource(control);
+                controlConnection.Open();
+                lock (lockObject)
+                {
+                    _hostsNodeTypeMap = GetCurrentServers(controlConnection);
+                }
+                CreatePool(_hostsNodeTypeMap);
+                controlConnection.Close();
+                break;
+            }
+            catch (Exception)
+            {
+                _connectionLogger.LogDebug("Could not connect to host: {host}", host);
+                initialHosts.Remove(host);
+                if (initialHosts.Count == 0)
+                {
+                    _connectionLogger.LogError("Failed to make Control Connection. No suitable host found");
+                    throw;
+                }
+            }
+
+        }
+    }
+
+    void ParseGeoLocations()
+    {
+        var values = settings.TopologyKeys?.Split(',');
+        Debug.Assert(values != null, nameof(values) + " != null");
+        foreach (var value in values)
+        {
+            var v = value.Split(':');
+            if (v.Length > 2 || value.EndsWith(":", StringComparison.Ordinal))
+            {
+                throw new InvalidExpressionException("Invalid value part for property" + settings.TopologyKeys + ":" + value);
+            }
+
+            if (v.Length == 1 )
+            {
+                HashSet<CloudPlacement>? primary = allowedPlacements.GetOrAdd(PRIMARY_PLACEMENTS, k => new HashSet<CloudPlacement>());
+                PopulatePlacementSet(v[0], primary);
+            }
+            else
+            {
+                var pref = Convert.ToInt32(v[1]);
+                if (pref == 1)
+                {
+                    HashSet<CloudPlacement>? primary;
+                    if (!allowedPlacements.TryGetValue(PRIMARY_PLACEMENTS, out primary))
+                    {
+                        primary = new HashSet<CloudPlacement>();
+                        allowedPlacements[PRIMARY_PLACEMENTS] = primary;
+                    }
+                    PopulatePlacementSet(v[0], primary);
+                }
+                else if (pref > 1 && pref <= MAX_PREFERENCE_VALUE)
+                {
+                    HashSet<CloudPlacement>? fallbackPlacements;
+                    if (!allowedPlacements.TryGetValue(pref, out fallbackPlacements))
+                    {
+                        fallbackPlacements = new HashSet<CloudPlacement>();
+                        allowedPlacements[pref] = fallbackPlacements;
+                    }
+                    PopulatePlacementSet(v[0], fallbackPlacements);
+                }
+                else
+                {
+                    throw new InvalidExpressionException("Invalid value part for property" + settings.TopologyKeys + ":" + value);
+                }
+            }
+        }
+    }
+
+    void PopulatePlacementSet(string placements, HashSet<CloudPlacement>? allowedPlacements)
+    {
+        var pStrings = placements.Split(',');
+        foreach (var pl in pStrings)
+        {
+            var placementParts = pl.Split('.');
+            if (placementParts.Length != 3 || placementParts[0].Equals("*") || placementParts[1].Equals("*"))
+            {
+                throw new InvalidExpressionException("Malformed " + settings.TopologyKeys + " property value:" + pl);
+            }
+
+            CloudPlacement cp = new CloudPlacement(placementParts[0], placementParts[1], placementParts[2]);
+
+            allowedPlacements?.Add(cp);
+
+        }
+    }
+
+
+    /// <summary>
+    /// Create a new pool
+    /// </summary>
+    internal new  void CreatePool(Dictionary<string,string> hostsmap)
+    {
+        lock (lockObject)
+        {
+            _hostsNodeTypeMap = hostsmap;
+            foreach(var host in _hostsNodeTypeMap)
+            {
+                var flag = 0;
+                foreach (var pool in _pools)
+                {
+                    if (host.Key.Equals(pool.Settings.Host, StringComparison.OrdinalIgnoreCase))
+                    {
+                        flag = 1;
+                        break;
+                    }
+                }
+
+                if (flag == 1)
+                    continue;
+                var poolSettings = settings.Clone();
+                poolSettings.Host = host.Key;
+                _connectionLogger.LogDebug("Adding {host} to connection pool", poolSettings.Host);
+                NpgsqlDataSource poolnew = settings.Pooling? new PoolingDataSource(poolSettings, dataSourceConfig): new UnpooledDataSource(poolSettings, dataSourceConfig);
+                _pools.Add(poolnew);
+                if (host.Value.Equals("primary", StringComparison.OrdinalIgnoreCase))
+                {
+                    poolToNumConnMapPrimary[poolnew] = 0;
+                }
+                else if (host.Value.Equals("read_replica", StringComparison.OrdinalIgnoreCase))
+                {
+                    poolToNumConnMapRR[poolnew] = 0;
+                }
+            }
+            unreachableHostsIndices.Clear();
+        }
+    }
+
+    new bool HasBetterNodeAvailable(int poolindex)
+    {
+        var chosenHost = _pools[poolindex].Settings.Host;
+        if (chosenHost != null && hostToPriorityMap.ContainsKey(chosenHost)) {
+            var chosenHostPriority = hostToPriorityMap[chosenHost];
+            for (var i = 1; i < chosenHostPriority; i++) {
+                if (hostToPriorityMap.Values.Contains(i)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    void UpdatePriorityMap(string host, string cloud, string region, string zone)
+    {
+        if (!unreachableHosts.Contains(host))
+        {
+            var priority = getPriority(cloud, region, zone);
+            hostToPriorityMap[host] = priority;
+        }
+    }
+
+    private int getPriority(string cloud, string region, string zone) {
+        CloudPlacement cp = new CloudPlacement(cloud, region, zone);
+        return getKeysByValue(cp);
+    }
+
+    private int getKeysByValue(CloudPlacement cp) {
+        int i;
+        HashSet<CloudPlacement>? placement;
+        for (i = 1; i <= MAX_PREFERENCE_VALUE; i++)
+        {
+            allowedPlacements.TryGetValue(i, out placement);
+            if (placement != null && allowedPlacements.Any()) {
+                if (cp.IsContainedIn(placement)){
+                    return i;
+                }
+            }
+        }
+        return MAX_PREFERENCE_VALUE + 1;
+    }
+
+    new Dictionary<string, string> GetCurrentServers(NpgsqlConnection conn)
+    {
+        NpgsqlCommand QUERY_SERVER = new NpgsqlCommand("Select * from yb_servers()",conn);
+        NpgsqlDataReader reader = QUERY_SERVER.ExecuteReader();
+        _lastServerFetchTime = DateTime.Now;
+        Dictionary<string, string> currentPrivateIps = new Dictionary<string, string>();
+
+        var hostConnectedTo = conn.Host;
+        hostToPriorityMap.Clear();
+
+        Debug.Assert(hostConnectedTo != null, nameof(hostConnectedTo) + " != null");
+        while (reader.Read())
+        {
+            var host = reader.GetString(reader.GetOrdinal("host"));
+            var publicHost = reader.GetString(reader.GetOrdinal("public_ip"));
+            var cloud = reader.GetString(reader.GetOrdinal("cloud"));
+            var region = reader.GetString(reader.GetOrdinal("region"));
+            var zone = reader.GetString(reader.GetOrdinal("zone"));
+            var nodeType = reader.GetString(reader.GetOrdinal("node_type"));
+            if (nodeType.Equals("read_replica", StringComparison.OrdinalIgnoreCase))
+            {
+                AllRRIps[host] = nodeType;
+            }
+            if (nodeType.Equals("primary", StringComparison.OrdinalIgnoreCase))
+            {
+                AllPrimaryIps[host] = nodeType;
+            }
+
+            UpdatePriorityMap(host, cloud, region, zone);
+
+            UpdateCurrentHostList(currentPrivateIps, host, publicHost, cloud, region, zone, nodeType);
+
+            if (hostConnectedTo.Equals(host))
+            {
+                UseHostColumn = true;
+            } else if (hostConnectedTo.Equals(publicHost)) {
+                UseHostColumn = false;
+            }
+
+        }
+        return GetPrivateOrPublicServers(currentPrivateIps, currentPublicIps);
+    }
+
+    Dictionary<string, string> GetServerNodeTypeMap(Dictionary<string, string> serversNodeTypeMap)
+    {
+        Dictionary<string,string> serversNodeTypeMapCopy = serversNodeTypeMap;
+        foreach (var serverNodeType in serversNodeTypeMap)
+        {
+            if (!unreachableHosts.Contains(serverNodeType.Key))
+            {
+                if (settings.LoadBalanceHosts == LoadBalanceHosts.OnlyPrimary || settings.LoadBalanceHosts == LoadBalanceHosts.PreferPrimary)
+                {
+                    if (serverNodeType.Value.Equals("read_replica", StringComparison.OrdinalIgnoreCase))
+                    {
+                        serversNodeTypeMapCopy.Remove(serverNodeType.Key);
+                    }
+                }
+                if (settings.LoadBalanceHosts == LoadBalanceHosts.OnlyRR || settings.LoadBalanceHosts == LoadBalanceHosts.PreferRR)
+                {
+                    if (serverNodeType.Value.Equals("primary", StringComparison.OrdinalIgnoreCase))
+                    {
+                        serversNodeTypeMapCopy.Remove(serverNodeType.Key);
+                    }
+                }
+            }
+        }
+
+        return serversNodeTypeMapCopy;
+    }
+    new Dictionary<string, string> GetPrivateOrPublicServers(Dictionary<string, string> privateHosts, Dictionary<string,string> publicHosts)
+    {
+        var exceptions = new List<Exception>();
+        Dictionary<string,string> serversNodeTypeMap = base.GetPrivateOrPublicServers(privateHosts, publicHosts);
+        // var flag = 0;
+
+        if (serversNodeTypeMap != null && serversNodeTypeMap.Any())
+        {
+            serversNodeTypeMap = GetServerNodeTypeMap(serversNodeTypeMap);
+
+            if (serversNodeTypeMap.Any())
+                return serversNodeTypeMap;
+        }
+
+        for (var i = FIRST_FALLBACK; i <= MAX_PREFERENCE_VALUE; i++)
+        {
+            fallbackPrivateIPs.TryGetValue(i, out var privateIp);
+            fallbackPublicIPs.TryGetValue(i, out var  publicIp);
+            if (privateIp == null)
+                privateIp = new Dictionary<string, string>();
+            if (publicIp == null)
+                publicIp = new Dictionary<string, string>();
+            if (privateIp.Any() ||  publicIp.Any())
+            {
+                serversNodeTypeMap = base.GetPrivateOrPublicServers(privateIp, publicIp);
+                serversNodeTypeMap = GetServerNodeTypeMap(serversNodeTypeMap);
+
+                if (serversNodeTypeMap.Any())
+                    return serversNodeTypeMap;
+            }
+        }
+
+        if (settings.FallBackToTopologyKeysOnly)
+            throw NoSuitableHostsException(exceptions);
+
+        fallbackPrivateIPs.TryGetValue(REST_OF_CLUSTER, out var privateIPRest);
+        fallbackPublicIPs.TryGetValue(REST_OF_CLUSTER, out var publicIPRest);
+
+        if (privateIPRest == null)
+            privateIPRest = new Dictionary<string, string>();
+        if (publicIPRest == null)
+            publicIPRest = new Dictionary<string, string>();
+
+        serversNodeTypeMap = base.GetPrivateOrPublicServers(privateIPRest, publicIPRest);
+        serversNodeTypeMap = GetServerNodeTypeMap(serversNodeTypeMap);
+
+        if (serversNodeTypeMap.Any())
+            return serversNodeTypeMap;
+
+        if (settings.LoadBalanceHosts == LoadBalanceHosts.PreferPrimary)
+        {
+            return AllRRIps;
+        }
+        else if (settings.LoadBalanceHosts == LoadBalanceHosts.PreferRR)
+        {
+            return AllPrimaryIps;
+        }
+
+        throw NoSuitableHostsException(exceptions);
+    }
+
+    void UpdateCurrentHostList(Dictionary<string, string> currentPrivateIPs, string host, string publicIP, string cloud, string region, string zone, string nodetype)
+    {
+        CloudPlacement cp = new CloudPlacement(cloud, region, zone);
+        Console.WriteLine("Adding host:" + host);
+        if (cp.IsContainedIn(allowedPlacements[PRIMARY_PLACEMENTS]))
+        {
+            currentPrivateIPs[host] = nodetype;
+            if (!string.IsNullOrEmpty(publicIP.Trim()))
+            {
+                currentPublicIps[publicIP] = nodetype;
+            }
+        }
+        else
+        {
+            foreach (var allowedCPs in allowedPlacements)
+            {
+                if (cp.IsContainedIn(allowedCPs.Value))
+                {
+                    Dictionary<string,string> hostsmap = fallbackPrivateIPs.GetOrAdd(allowedCPs.Key, k => new Dictionary<string, string>());
+                    hostsmap.Add(host, nodetype);
+
+                    if (!string.IsNullOrEmpty(publicIP.Trim()))
+                    {
+                        Dictionary<string,string> publicIPsMap = fallbackPublicIPs.GetOrAdd(allowedCPs.Key, k => new Dictionary<string, string>());
+                        publicIPsMap.Add(publicIP, nodetype);
+                    }
+
+                    return;
+                }
+            }
+
+            Dictionary<string,string> remainingHosts = fallbackPrivateIPs.GetOrAdd(REST_OF_CLUSTER, k => new Dictionary<string, string>());
+            remainingHosts.Add(host, nodetype);
+            if (!string.IsNullOrEmpty(publicIP.Trim()))
+            {
+                Dictionary<string, string> remainingPublicIPs =
+                    fallbackPublicIPs.GetOrAdd(REST_OF_CLUSTER, k => new Dictionary<string, string>());
+                remainingPublicIPs.Add(publicIP, nodetype);
+            }
+        }
+    }
+
+    class CloudPlacement
+    {
+        private string cloud;
+        private string region;
+        private string zone;
+
+        internal CloudPlacement(string cloud, string region, string zone) {
+            this.cloud = cloud;
+            this.region = region;
+            this.zone = zone;
+        }
+
+        public bool EqualPlacements(CloudPlacement obj)
+        {
+            var equal = false;
+            equal = cloud.Equals(obj.cloud, StringComparison.OrdinalIgnoreCase) &&
+                    region.Equals(obj.region, StringComparison.OrdinalIgnoreCase) &&
+                    zone.Equals(obj.zone, StringComparison.OrdinalIgnoreCase);
+            return equal;
+        }
+
+        public bool IsContainedIn(HashSet<CloudPlacement>? set)
+        {
+            Debug.Assert(set != null, nameof(set) + " != null");
+            foreach (var cp in set)
+            {
+               if (cp.zone.Equals("*"))
+               {
+                   if (cp.cloud.Equals(cloud, StringComparison.OrdinalIgnoreCase) &&
+                       cp.region.Equals(region, StringComparison.OrdinalIgnoreCase))
+                   {
+                       return true;
+                   }
+               }
+               else
+               {
+                   if (cp.cloud.Equals(cloud, StringComparison.OrdinalIgnoreCase) &&
+                       cp.region.Equals(region, StringComparison.OrdinalIgnoreCase) &&
+                       cp.zone.Equals(zone, StringComparison.OrdinalIgnoreCase))
+                   {
+                       return true;
+                   }
+               }
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Npgsql.Tests/LoadBalancerTests.cs
+++ b/test/Npgsql.Tests/LoadBalancerTests.cs
@@ -15,7 +15,7 @@ public class LoadBalancerTests : YBTestUtils
     [Test]
     public async Task TestLoadBalance1()
     {
-        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0";
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=preferrr;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         // CreateCluster();
@@ -26,6 +26,10 @@ public class LoadBalancerTests : YBTestUtils
             await VerifyOn("127.0.0.1", numConns/3);
             await VerifyOn("127.0.0.2", numConns/3);
             await VerifyOn("127.0.0.3", numConns / 3);
+            await VerifyOn("127.0.0.4", numConns / 3);
+            await VerifyOn("127.0.0.5", numConns / 3);
+            await VerifyOn("127.0.0.6", numConns / 3);
+
         }
         catch (Exception ex)
         {

--- a/test/Npgsql.Tests/LoadBalancerTests.cs
+++ b/test/Npgsql.Tests/LoadBalancerTests.cs
@@ -15,7 +15,7 @@ public class LoadBalancerTests : YBTestUtils
     [Test]
     public async Task TestLoadBalance1()
     {
-        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=preferrr;Timeout=0";
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=any;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         // CreateCluster();

--- a/test/Npgsql.Tests/LoadBalancerTests.cs
+++ b/test/Npgsql.Tests/LoadBalancerTests.cs
@@ -18,7 +18,7 @@ public class LoadBalancerTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=any;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateCluster();
 
         try
         {
@@ -26,9 +26,6 @@ public class LoadBalancerTests : YBTestUtils
             await VerifyOn("127.0.0.1", numConns/3);
             await VerifyOn("127.0.0.2", numConns/3);
             await VerifyOn("127.0.0.3", numConns / 3);
-            await VerifyOn("127.0.0.4", numConns / 3);
-            await VerifyOn("127.0.0.5", numConns / 3);
-            await VerifyOn("127.0.0.6", numConns / 3);
 
         }
         catch (Exception ex)
@@ -42,6 +39,10 @@ public class LoadBalancerTests : YBTestUtils
             {
                 conn.Close();
             }
+            Console.WriteLine("Verifying if all connections are closed...");
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
             DestroyCluster();
         }
     }
@@ -86,6 +87,8 @@ public class LoadBalancerTests : YBTestUtils
                         conn.Close();
                     }
                 }
+                VerifyLocal("127.0.0.2", 0);
+                VerifyLocal("127.0.0.3", 0);
                 DestroyCluster();
             }
         }
@@ -95,8 +98,8 @@ public class LoadBalancerTests : YBTestUtils
     {
         var connStringBuilder = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0";
 
-        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        List<NpgsqlConnection> allConns = new List<NpgsqlConnection>();
+        CreateCluster();
         try
         {
             List<Thread> threads = new List<Thread>();
@@ -104,7 +107,13 @@ public class LoadBalancerTests : YBTestUtils
             var numThreads = 15;
             for (var i = 0; i < numThreads; i++)
             {
-                Thread thread = new Thread(() => { conn = CreateConnections(connStringBuilder, numConns); });
+                Thread thread = new Thread(() => {
+                    var threadConns = CreateConnections(connStringBuilder, numConns); // Each thread uses its own list
+                    lock (allConns)
+                    {
+                        allConns.AddRange(threadConns); // Safely add to the shared list
+                    }
+                });
                 threads.Add(thread);
             }
 
@@ -116,7 +125,6 @@ public class LoadBalancerTests : YBTestUtils
             foreach (var thread in threads)
             {
                 thread.Join();
-                conns.AddRange(conn);
             }
             await VerifyOn("127.0.0.1", numThreads * numConns/3);
             await VerifyOn("127.0.0.2", numThreads * numConns/3);
@@ -129,10 +137,14 @@ public class LoadBalancerTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
+            Console.WriteLine("Conns count" + allConns.Count);
+            foreach (var conn in allConns)
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
             DestroyCluster();
         }
     }

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -1,1185 +1,1185 @@
-﻿using YBNpgsql.Internal;
-using YBNpgsql.Tests.Support;
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Transactions;
-using YBNpgsql.Properties;
-using static YBNpgsql.Tests.Support.MockState;
-using static YBNpgsql.Tests.TestUtil;
-using IsolationLevel = System.Transactions.IsolationLevel;
-using TransactionStatus = YBNpgsql.Internal.TransactionStatus;
-
-namespace YBNpgsql.Tests;
-
-public class MultipleHostsTests : TestBase
-{
-    static readonly object[] MyCases =
-    {
-        new object[] { TargetSessionAttributes.Standby,        new[] { Primary,         Standby         }, 1 },
-        new object[] { TargetSessionAttributes.Standby,        new[] { PrimaryReadOnly, Standby         }, 1 },
-        new object[] { TargetSessionAttributes.PreferStandby,  new[] { Primary,         Standby         }, 1 },
-        new object[] { TargetSessionAttributes.PreferStandby,  new[] { PrimaryReadOnly, Standby         }, 1 },
-        new object[] { TargetSessionAttributes.PreferStandby,  new[] { Primary,         Primary         }, 0 },
-        new object[] { TargetSessionAttributes.Primary,        new[] { Standby,         Primary         }, 1 },
-        new object[] { TargetSessionAttributes.Primary,        new[] { Standby,         PrimaryReadOnly }, 1 },
-        new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         Primary         }, 1 },
-        new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         PrimaryReadOnly }, 1 },
-        new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         Standby         }, 0 },
-        new object[] { TargetSessionAttributes.Any,            new[] { Standby,         Primary         }, 0 },
-        new object[] { TargetSessionAttributes.Any,            new[] { Primary,         Standby         }, 0 },
-        new object[] { TargetSessionAttributes.Any,            new[] { PrimaryReadOnly, Standby         }, 0 },
-        new object[] { TargetSessionAttributes.ReadWrite,      new[] { Standby,         Primary         }, 1 },
-        new object[] { TargetSessionAttributes.ReadWrite,      new[] { PrimaryReadOnly, Primary         }, 1 },
-        new object[] { TargetSessionAttributes.ReadOnly,       new[] { Primary,         Standby         }, 1 },
-        new object[] { TargetSessionAttributes.ReadOnly,       new[] { PrimaryReadOnly, Standby         }, 0 }
-    };
-
-    [Test]
-    [TestCaseSource(nameof(MyCases))]
-    public async Task Connect_to_correct_host_pooled(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
-    {
-        var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
-        await using var __ = new DisposableWrapper(postmasters);
-
-        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(postmasters),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            Pooling = true
-        };
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
-            .BuildMultiHost();
-        await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
-
-        Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
-
-        for (var i = 0; i <= expectedServer; i++)
-            _ = await postmasters[i].WaitForServerConnection();
-    }
-
-    [Test]
-    [TestCaseSource(nameof(MyCases))]
-    public async Task Connect_to_correct_host_unpooled(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
-    {
-        var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
-        await using var __ = new DisposableWrapper(postmasters);
-
-        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(postmasters),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            Pooling = false
-        };
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
-            .BuildMultiHost();
-        await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
-
-        Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
-
-        for (var i = 0; i <= expectedServer; i++)
-            _ = await postmasters[i].WaitForServerConnection();
-    }
-
-    [Test]
-    [TestCaseSource(nameof(MyCases))]
-    public async Task Connect_to_correct_host_with_available_idle(
-        TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
-    {
-        var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
-        await using var __ = new DisposableWrapper(postmasters);
-
-        // First, open and close a connection with the TargetSessionAttributes matching the first server.
-        // This ensures wew have an idle connection in the pool.
-        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(postmasters),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-        };
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
-            .BuildMultiHost();
-        var idleConnTargetSessionAttributes = servers[0] switch
-        {
-            Primary => TargetSessionAttributes.ReadWrite,
-            PrimaryReadOnly => TargetSessionAttributes.ReadOnly,
-            Standby => TargetSessionAttributes.Standby,
-            _ => throw new ArgumentOutOfRangeException()
-        };
-        await using (_ = await dataSource.OpenConnectionAsync(idleConnTargetSessionAttributes))
-        {
-            // Do nothing, close to have an idle connection in the pool.
-        }
-
-        // Now connect with the test TargetSessionAttributes
-
-        await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
-
-        Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
-
-        for (var i = 0; i <= expectedServer; i++)
-            _ = await postmasters[i].WaitForServerConnection();
-    }
-
-    [Test]
-    [TestCase(TargetSessionAttributes.Standby,   new[] { Primary,         Primary })]
-    [TestCase(TargetSessionAttributes.Primary,   new[] { Standby,         Standby })]
-    [TestCase(TargetSessionAttributes.ReadWrite, new[] { PrimaryReadOnly, Standby })]
-    [TestCase(TargetSessionAttributes.ReadOnly,  new[] { Primary,         Primary })]
-    public async Task Valid_host_not_found(TargetSessionAttributes targetSessionAttributes, MockState[] servers)
-    {
-        var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
-        await using var __ = new DisposableWrapper(postmasters);
-
-        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(postmasters),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-        };
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
-            .BuildMultiHost();
-
-        var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await dataSource.OpenConnectionAsync(targetSessionAttributes))!;
-        Assert.That(exception.Message, Is.EqualTo("No suitable host was found."));
-        Assert.That(exception.InnerException, Is.Null);
-
-        for (var i = 0; i < servers.Length; i++)
-            _ = await postmasters[i].WaitForServerConnection();
-    }
-
-    [Test, Platform(Exclude = "MacOsX", Reason = "#3786")]
-    public void All_hosts_are_down()
-    {
-        // Different exception raised in .NET Core 3.1, skip (NUnit doesn't seem to support detecting .NET Core versions)
-        if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Core 3.1"))
-            return;
-
-        var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
-
-        using var socket1 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-        socket1.Bind(endpoint);
-        var localEndPoint1 = (IPEndPoint)socket1.LocalEndPoint!;
-
-        using var socket2 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-        socket2.Bind(endpoint);
-        var localEndPoint2 = (IPEndPoint)socket2.LocalEndPoint!;
-
-        // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
-
-        var connectionString = new NpgsqlConnectionStringBuilder
-        {
-            Host = $"{localEndPoint1.Address}:{localEndPoint1.Port},{localEndPoint2.Address}:{localEndPoint2.Port}"
-        }.ConnectionString;
-        using var dataSource = new NpgsqlDataSourceBuilder(connectionString).BuildMultiHost();
-
-        var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any))!;
-        var aggregateException = (AggregateException)exception.InnerException!;
-        Assert.That(aggregateException.InnerExceptions, Has.Count.EqualTo(2));
-
-        for (var i = 0; i < aggregateException.InnerExceptions.Count; i++)
-        {
-            Assert.That(aggregateException.InnerExceptions[i], Is.TypeOf<NpgsqlException>()
-                .With.InnerException.TypeOf<SocketException>()
-                .With.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(SocketError.ConnectionRefused));
-        }
-    }
-
-    [Test]
-    public async Task All_hosts_are_unavailable(
-        [Values] bool pooling,
-        [Values(PostgresErrorCodes.InvalidCatalogName, PostgresErrorCodes.CannotConnectNow)] string errorCode)
-    {
-        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary, startupErrorCode: errorCode);
-        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby, startupErrorCode: errorCode);
-
-        var builder = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            Pooling = pooling,
-        };
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString).BuildMultiHost();
-
-        var ex = Assert.ThrowsAsync<PostgresException>(async () => await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any))!;
-        Assert.That(ex.SqlState, Is.EqualTo(errorCode));
-    }
-
-    [Test]
-    [Platform(Exclude = "MacOsX", Reason = "Flaky in CI on Mac")]
-    public async Task First_host_is_down()
-    {
-        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-        var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
-        socket.Bind(endpoint);
-        var localEndPoint = (IPEndPoint)socket.LocalEndPoint!;
-        // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
-
-        await using var postmaster = PgPostmasterMock.Start(state: Primary);
-
-        var connectionString = new NpgsqlConnectionStringBuilder
-        {
-            Host = $"{localEndPoint.Address}:{localEndPoint.Port},{postmaster.Host}:{postmaster.Port}",
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
-        }.ConnectionString;
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(connectionString).BuildMultiHost();
-
-        await using var conn = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any);
-        Assert.That(conn.Port, Is.EqualTo(postmaster.Port));
-    }
-
-    [Test]
-    [TestCase("any")]
-    [TestCase("primary")]
-    [TestCase("standby")]
-    [TestCase("prefer-primary")]
-    [TestCase("prefer-standby")]
-    [TestCase("read-write")]
-    [TestCase("read-only")]
-    public async Task TargetSessionAttributes_with_single_host(string targetSessionAttributes)
-    {
-        var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-        {
-            TargetSessionAttributes = targetSessionAttributes
-        }.ConnectionString;
-
-        if (targetSessionAttributes == "any")
-        {
-            await using var postmasterMock = PgPostmasterMock.Start(ConnectionString);
-            using var pool = CreateTempPool(postmasterMock.ConnectionString, out connectionString);
-            await using var conn = new NpgsqlConnection(connectionString);
-            await conn.OpenAsync();
-            _ = await postmasterMock.WaitForServerConnection();
-        }
-        else
-        {
-            Assert.That(() => new NpgsqlConnection(connectionString), Throws.Exception.TypeOf<NotSupportedException>());
-        }
-    }
-
-    [Test]
-    public void TargetSessionAttributes_default_is_null()
-        => Assert.That(new NpgsqlConnectionStringBuilder().TargetSessionAttributes, Is.Null);
-
-    [Test]
-    [NonParallelizable] // Sets environment variable
-    public async Task TargetSessionAttributes_uses_environment_variable()
-    {
-        using var envVarResetter = SetEnvironmentVariable("PGTARGETSESSIONATTRS", "prefer-standby");
-
-        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
-        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
-
-        var builder = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
-        };
-
-        Assert.That(builder.TargetSessionAttributes, Is.Null);
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString)
-            .BuildMultiHost();
-
-        await using var conn = await dataSource.OpenConnectionAsync();
-        Assert.That(conn.Port, Is.EqualTo(standbyPostmaster.Port));
-    }
-
-    [Test]
-    public void TargetSessionAttributes_invalid_throws()
-        => Assert.Throws<ArgumentException>(() =>
-            new NpgsqlConnectionStringBuilder
-            {
-                TargetSessionAttributes = nameof(TargetSessionAttributes_invalid_throws)
-            });
-
-    [Test]
-    public void HostRecheckSeconds_default_value()
-    {
-        var builder = new NpgsqlConnectionStringBuilder();
-        Assert.That(builder.HostRecheckSeconds, Is.EqualTo(10));
-        Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(10)));
-    }
-
-    [Test]
-    public void HostRecheckSeconds_zero_value()
-    {
-        var builder = new NpgsqlConnectionStringBuilder
-        {
-            HostRecheckSeconds = 0,
-        };
-        Assert.That(builder.HostRecheckSeconds, Is.EqualTo(0));
-        Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(-1)));
-    }
-
-    [Test]
-    public void HostRecheckSeconds_invalid_throws()
-        => Assert.Throws<ArgumentException>(() =>
-            new NpgsqlConnectionStringBuilder
-            {
-                HostRecheckSeconds = -1
-            });
-
-    [Test]
-    public async Task Connect_with_load_balancing()
-    {
-        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
-        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
-
-        var defaultCsb = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            MaxPoolSize = 1,
-            LoadBalanceHosts = true,
-        };
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
-            .BuildMultiHost();
-
-        NpgsqlConnector firstConnector;
-        NpgsqlConnector secondConnector;
-
-        await using (var firstConnection = await dataSource.OpenConnectionAsync())
-        {
-            firstConnector = firstConnection.Connector!;
-        }
-
-        await using (var secondConnection = await dataSource.OpenConnectionAsync())
-        {
-            secondConnector = secondConnection.Connector!;
-        }
-
-        Assert.AreNotSame(firstConnector, secondConnector);
-
-        await using (var firstBalancedConnection = await dataSource.OpenConnectionAsync())
-        {
-            Assert.AreSame(firstConnector, firstBalancedConnection.Connector);
-        }
-
-        await using (var secondBalancedConnection = await dataSource.OpenConnectionAsync())
-        {
-            Assert.AreSame(secondConnector, secondBalancedConnection.Connector);
-        }
-
-        await using (var thirdBalancedConnection = await dataSource.OpenConnectionAsync())
-        {
-            Assert.AreSame(firstConnector, thirdBalancedConnection.Connector);
-        }
-    }
-
-    [Test]
-    public async Task Connect_without_load_balancing()
-    {
-        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
-        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
-
-        var defaultCsb = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            MaxPoolSize = 1,
-            LoadBalanceHosts = false,
-        };
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
-            .BuildMultiHost();
-
-        NpgsqlConnector firstConnector;
-        NpgsqlConnector secondConnector;
-
-        await using (var firstConnection = await dataSource.OpenConnectionAsync())
-        {
-            firstConnector = firstConnection.Connector!;
-        }
-        await using (var secondConnection = await dataSource.OpenConnectionAsync())
-        {
-            Assert.AreSame(firstConnector, secondConnection.Connector);
-        }
-        await using (var firstConnection = await dataSource.OpenConnectionAsync())
-        await using (var secondConnection = await dataSource.OpenConnectionAsync())
-        {
-            secondConnector = secondConnection.Connector!;
-        }
-
-        Assert.AreNotSame(firstConnector, secondConnector);
-
-        await using (var firstUnbalancedConnection = await dataSource.OpenConnectionAsync())
-        {
-            Assert.AreSame(firstConnector, firstUnbalancedConnection.Connector);
-        }
-
-        await using (var secondUnbalancedConnection = await dataSource.OpenConnectionAsync())
-        {
-            Assert.AreSame(firstConnector, secondUnbalancedConnection.Connector);
-        }
-    }
-
-    [Test]
-    public async Task Connect_state_changing_hosts([Values] bool alwaysCheckHostState)
-    {
-        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
-        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
-
-        var defaultCsb = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            MaxPoolSize = 1,
-            HostRecheckSeconds = alwaysCheckHostState ? 0 : int.MaxValue,
-            NoResetOnClose = true,
-        };
-
-        await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
-            .BuildMultiHost();
-
-        NpgsqlConnector firstConnector;
-        NpgsqlConnector secondConnector;
-        var firstServerTask = Task.Run(async () =>
-        {
-            var server = await primaryPostmaster.WaitForServerConnection();
-            if (!alwaysCheckHostState)
-                return;
-
-            // If we always check the host, we will send the request for the state
-            // even though we got one while opening the connection
-            await server.SendMockState(Primary);
-
-            // Update the state after a 'failover'
-            await server.SendMockState(Standby);
-        });
-        var secondServerTask = Task.Run(async () =>
-        {
-            var server = await standbyPostmaster.WaitForServerConnection();
-            if (!alwaysCheckHostState)
-                return;
-
-            // If we always check the host, we will send the request for the state
-            // even though we got one while opening the connection
-            await server.SendMockState(Standby);
-
-            // As TargetSessionAttributes is 'prefer', it does another cycle for the 'unpreferred'
-            await server.SendMockState(Standby);
-            // Update the state after a 'failover'
-            await server.SendMockState(Primary);
-        });
-
-        await using (var firstConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary))
-        await using (var secondConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary))
-        {
-            firstConnector = firstConnection.Connector!;
-            secondConnector = secondConnection.Connector!;
-        }
-
-        await using var thirdConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary);
-        Assert.AreSame(alwaysCheckHostState ? secondConnector : firstConnector, thirdConnection.Connector);
-
-        await firstServerTask;
-        await secondServerTask;
-    }
-
-    [Test]
-    public void Database_state_cache_basic()
-    {
-        using var dataSource = CreateDataSource();
-        var timeStamp = DateTime.UtcNow;
-
-        dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadWrite, timeStamp, TimeSpan.Zero);
-        Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState());
-
-        // Update with the same timestamp - shouldn't change anything
-        dataSource.UpdateDatabaseState(DatabaseState.Standby, timeStamp, TimeSpan.Zero);
-        Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState());
-
-        // Update with a new timestamp
-        timeStamp = timeStamp.AddSeconds(1);
-        dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadOnly, timeStamp, TimeSpan.Zero);
-        Assert.AreEqual(DatabaseState.PrimaryReadOnly, dataSource.GetDatabaseState());
-
-        // Expired state returns as Unknown (depending on ignoreExpiration)
-        timeStamp = timeStamp.AddSeconds(1);
-        dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadWrite, timeStamp, TimeSpan.FromSeconds(-1));
-        Assert.AreEqual(DatabaseState.Unknown, dataSource.GetDatabaseState(ignoreExpiration: false));
-        Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState(ignoreExpiration: true));
-    }
-
-    [Test]
-    public async Task Offline_state_on_connection_failure()
-    {
-        await using var server = PgPostmasterMock.Start(ConnectionString, startupErrorCode: PostgresErrorCodes.ConnectionFailure);
-        await using var dataSource = server.CreateDataSource();
-        await using var conn = dataSource.CreateConnection();
-
-        var ex = Assert.ThrowsAsync<PostgresException>(conn.OpenAsync)!;
-        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.ConnectionFailure));
-
-        var state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Offline));
-    }
-
-    [Test]
-    public async Task Unknown_state_on_connection_authentication_failure()
-    {
-        await using var server = PgPostmasterMock.Start(ConnectionString, startupErrorCode: PostgresErrorCodes.InvalidAuthorizationSpecification);
-        await using var dataSource = server.CreateDataSource();
-        await using var conn = dataSource.CreateConnection();
-
-        var ex = Assert.ThrowsAsync<PostgresException>(conn.OpenAsync)!;
-        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.InvalidAuthorizationSpecification));
-
-        var state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-    }
-
-    [Test]
-    public async Task Offline_state_on_query_execution_pg_critical_failure()
-    {
-        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-        await using var dataSource = postmaster.CreateDataSource();
-        await using var conn = await dataSource.OpenConnectionAsync();
-        await using var anotherConn = await dataSource.OpenConnectionAsync();
-        await anotherConn.CloseAsync();
-
-        var state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-
-        var server = await postmaster.WaitForServerConnection();
-        await server.WriteErrorResponse(PostgresErrorCodes.CrashShutdown).FlushAsync();
-
-        var ex = Assert.ThrowsAsync<PostgresException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
-        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.CrashShutdown));
-        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-
-        state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Offline));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
-    }
-
-    [Test, NonParallelizable]
-    public async Task Offline_state_on_query_execution_pg_non_critical_failure()
-    {
-        await using var dataSource = CreateDataSource();
-        await using var conn = await dataSource.OpenConnectionAsync();
-
-        // Starting with PG14 we get the cluster's state from PG automatically
-        var expectedState = conn.PostgreSqlVersion.Major > 13 ? DatabaseState.PrimaryReadWrite : DatabaseState.Unknown;
-
-        var state = dataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(expectedState));
-        Assert.That(dataSource.Statistics.Total, Is.EqualTo(1));
-
-        var ex = Assert.ThrowsAsync<PostgresException>(() => conn.ExecuteNonQueryAsync("SELECT abc"))!;
-        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.UndefinedColumn));
-        Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
-
-        state = dataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(expectedState));
-        Assert.That(dataSource.Statistics.Total, Is.EqualTo(1));
-    }
-
-    [Test]
-    public async Task Offline_state_on_query_execution_IOException()
-    {
-        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-        await using var dataSource = postmaster.CreateDataSource();
-        await using var conn = await dataSource.OpenConnectionAsync();
-        await using var anotherConn = await dataSource.OpenConnectionAsync();
-        await anotherConn.CloseAsync();
-
-        var state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-
-        var server = await postmaster.WaitForServerConnection();
-        server.Close();
-
-        var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
-        Assert.That(ex.InnerException, Is.InstanceOf<IOException>());
-        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-
-        state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Offline));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
-    }
-
-    [Test]
-    public async Task Offline_state_on_query_execution_TimeoutException()
-    {
-        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-        var dataSourceBuilder = postmaster.GetDataSourceBuilder();
-        dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
-        dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = 1;
-        await using var dataSource = dataSourceBuilder.Build();
-
-        await using var conn = await dataSource.OpenConnectionAsync();
-        await using var anotherConn = await dataSource.OpenConnectionAsync();
-        await anotherConn.CloseAsync();
-
-        var state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-
-        var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
-        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
-        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-
-        state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Offline));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
-    }
-
-    [Test]
-    public async Task Unknown_state_on_query_execution_TimeoutException_with_disabled_cancellation()
-    {
-        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-        var dataSourceBuilder = postmaster.GetDataSourceBuilder();
-        dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
-        dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = -1;
-        await using var dataSource = dataSourceBuilder.Build();
-
-        await using var conn = await dataSource.OpenConnectionAsync();
-        await using var anotherConn = await dataSource.OpenConnectionAsync();
-        await anotherConn.CloseAsync();
-
-        var state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-
-        var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
-        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
-        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-
-        state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-    }
-
-    [Test]
-    public async Task Unknown_state_on_query_execution_cancellation_with_disabled_cancellation_timeout()
-    {
-        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-        var dataSourceBuilder = postmaster.GetDataSourceBuilder();
-        dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 30;
-        dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = -1;
-        await using var dataSource = dataSourceBuilder.Build();
-
-        await using var conn = await dataSource.OpenConnectionAsync();
-        await using var anotherConn = await dataSource.OpenConnectionAsync();
-        await anotherConn.CloseAsync();
-
-        var state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-
-        using var cts = new CancellationTokenSource();
-
-        var query = conn.ExecuteNonQueryAsync("SELECT 1", cancellationToken: cts.Token);
-        cts.Cancel();
-        var ex = Assert.ThrowsAsync<OperationCanceledException>(async () => await query)!;
-        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
-        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-
-        state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-    }
-
-    [Test]
-    public async Task Unknown_state_on_query_execution_TimeoutException_with_cancellation_failure()
-    {
-        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-        var dataSourceBuilder = postmaster.GetDataSourceBuilder();
-        dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
-        dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = 0;
-        await using var dataSource = dataSourceBuilder.Build();
-
-        await using var conn = await dataSource.OpenConnectionAsync();
-
-        var state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-
-        var server = await postmaster.WaitForServerConnection();
-
-        var query = conn.ExecuteNonQueryAsync("SELECT 1");
-
-        await postmaster.WaitForCancellationRequest();
-        await server.WriteCancellationResponse().WriteReadyForQuery().FlushAsync();
-
-        var ex = Assert.ThrowsAsync<NpgsqlException>(async () => await query)!;
-        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
-        Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
-
-        state = conn.NpgsqlDataSource.GetDatabaseState();
-        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-    }
-
-    [Test]
-    public async Task Clear_pool_one_host_only_on_admin_shutdown()
-    {
-        await using var primaryPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
-        await using var standbyPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
-        var dataSourceBuilder = new NpgsqlDataSourceBuilder
-        {
-            ConnectionStringBuilder =
-            {
-                Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-                MaxPoolSize = 2
-            }
-        };
-        await using var multiHostDataSource = dataSourceBuilder.BuildMultiHost();
-        await using var preferPrimaryDataSource = multiHostDataSource.WithTargetSession(TargetSessionAttributes.PreferPrimary);
-
-        await using var primaryConn = await preferPrimaryDataSource.OpenConnectionAsync();
-        await using var anotherPrimaryConn = await preferPrimaryDataSource.OpenConnectionAsync();
-        await using var standbyConn = await preferPrimaryDataSource.OpenConnectionAsync();
-        var primaryDataSource = primaryConn.Connector!.DataSource;
-        var standbyDataSource = standbyConn.Connector!.DataSource;
-        await anotherPrimaryConn.CloseAsync();
-        await standbyConn.CloseAsync();
-
-        Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.PrimaryReadWrite));
-        Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
-        Assert.That(primaryConn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(3));
-
-        var server = await primaryPostmaster.WaitForServerConnection();
-        await server.WriteErrorResponse(PostgresErrorCodes.AdminShutdown).FlushAsync();
-
-        var ex = Assert.ThrowsAsync<PostgresException>(() => primaryConn.ExecuteNonQueryAsync("SELECT 1"))!;
-        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.AdminShutdown));
-        Assert.That(primaryConn.State, Is.EqualTo(ConnectionState.Closed));
-
-        Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Offline));
-        Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
-        Assert.That(primaryConn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-
-        multiHostDataSource.ClearDatabaseStates();
-        Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
-    }
-
-    [Test]
-    [TestCase("any", true)]
-    [TestCase("primary", true)]
-    [TestCase("standby", false)]
-    [TestCase("prefer-primary", true)]
-    [TestCase("prefer-standby", false)]
-    [TestCase("read-write", true)]
-    [TestCase("read-only", false)]
-    public async Task Transaction_enlist_reuses_connection(string targetSessionAttributes, bool primary)
-    {
-        await using var primaryPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
-        await using var standbyPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
-        var csb = new NpgsqlConnectionStringBuilder
-        {
-            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-            TargetSessionAttributes = targetSessionAttributes,
-            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            MaxPoolSize = 10,
-        };
-
-        using var _ = CreateTempPool(csb, out var connString);
-
-        using var scope = new TransactionScope(TransactionScopeOption.Required,
-            new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }, TransactionScopeAsyncFlowOption.Enabled);
-
-        var query1Task = Query(connString);
-
-        var server = primary
-            ? await primaryPostmaster.WaitForServerConnection()
-            : await standbyPostmaster.WaitForServerConnection();
-
-        await server
-            .WriteCommandComplete()
-            .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
-            .WriteParseComplete()
-            .WriteBindComplete()
-            .WriteNoData()
-            .WriteCommandComplete()
-            .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
-            .FlushAsync();
-        await query1Task;
-
-        var query2Task = Query(connString);
-        await server
-            .WriteParseComplete()
-            .WriteBindComplete()
-            .WriteNoData()
-            .WriteCommandComplete()
-            .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
-            .FlushAsync();
-        await query2Task;
-
-        await server
-            .WriteCommandComplete()
-            .WriteReadyForQuery()
-            .FlushAsync();
-        scope.Complete();
-
-        async Task Query(string connectionString)
-        {
-            await using var conn = new NpgsqlConnection(connectionString);
-            await conn.OpenAsync();
-
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = "SELECT 1";
-            await cmd.ExecuteNonQueryAsync();
-        }
-    }
-
-    [Test]
-    public async Task Primary_host_failover_can_connect()
-    {
-        await using var firstPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
-        await using var secondPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
-        var dataSourceBuilder = new NpgsqlDataSourceBuilder
-        {
-            ConnectionStringBuilder =
-            {
-                Host = MultipleHosts(firstPostmaster, secondPostmaster),
-                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-                HostRecheckSeconds = 5
-            }
-        };
-        await using var multiHostDataSource = dataSourceBuilder.BuildMultiHost();
-        var (firstDataSource, secondDataSource) = (multiHostDataSource.Pools[0], multiHostDataSource.Pools[1]);
-        await using var primaryDataSource = multiHostDataSource.WithTargetSession(TargetSessionAttributes.Primary);
-
-        await using var conn = await primaryDataSource.OpenConnectionAsync();
-        Assert.That(conn.Port, Is.EqualTo(firstPostmaster.Port));
-        var firstServer = await firstPostmaster.WaitForServerConnection();
-        await firstServer
-            .WriteErrorResponse(PostgresErrorCodes.AdminShutdown)
-            .FlushAsync();
-
-        var failoverEx = Assert.ThrowsAsync<PostgresException>(async () => await conn.ExecuteNonQueryAsync("SELECT 1"))!;
-        Assert.That(failoverEx.SqlState, Is.EqualTo(PostgresErrorCodes.AdminShutdown));
-
-        var noHostFoundEx = Assert.ThrowsAsync<NpgsqlException>(async () => await conn.OpenAsync())!;
-        Assert.That(noHostFoundEx.Message, Is.EqualTo("No suitable host was found."));
-
-        Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Offline));
-        Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
-
-        firstPostmaster.State = Standby;
-        secondPostmaster.State = Primary;
-        var secondServer = await secondPostmaster.WaitForServerConnection();
-        await secondServer.SendMockState(Primary);
-
-        await Task.Delay(TimeSpan.FromSeconds(10));
-        Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
-        Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
-
-        await conn.OpenAsync();
-        Assert.That(conn.Port, Is.EqualTo(secondPostmaster.Port));
-        Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
-        Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.PrimaryReadWrite));
-    }
-
-    [Test, NonParallelizable]
-    public void IntegrationTest([Values] bool loadBalancing, [Values] bool alwaysCheckHostState)
-    {
-        PoolManager.Reset();
-
-        var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
-        {
-            ConnectionStringBuilder =
-            {
-                Host = "localhost,127.0.0.1",
-                Pooling = true,
-                MaxPoolSize = 2,
-                LoadBalanceHosts = loadBalancing,
-                HostRecheckSeconds = alwaysCheckHostState ? 0 : 10,
-            }
-        };
-        using var dataSource = dataSourceBuilder.BuildMultiHost();
-
-        var queriesDone = 0;
-
-        var clientsTask = Task.WhenAll(
-            Client(dataSource, TargetSessionAttributes.Any),
-            Client(dataSource, TargetSessionAttributes.Primary),
-            Client(dataSource, TargetSessionAttributes.PreferPrimary),
-            Client(dataSource, TargetSessionAttributes.PreferStandby),
-            Client(dataSource, TargetSessionAttributes.ReadWrite));
-
-        var onlyStandbyClient = Client(dataSource, TargetSessionAttributes.Standby);
-        var readOnlyClient = Client(dataSource, TargetSessionAttributes.ReadOnly);
-
-        Assert.DoesNotThrowAsync(() => clientsTask);
-        Assert.ThrowsAsync<NpgsqlException>(() => onlyStandbyClient);
-        Assert.ThrowsAsync<NpgsqlException>(() => readOnlyClient);
-        Assert.AreEqual(125, queriesDone);
-
-        Task Client(NpgsqlMultiHostDataSource multiHostDataSource, TargetSessionAttributes targetSessionAttributes)
-        {
-            var dataSource = multiHostDataSource.WithTargetSession(targetSessionAttributes);
-            var tasks = new List<Task>(5);
-
-            for (var i = 0; i < 5; i++)
-            {
-                tasks.Add(Task.Run(() => Query(dataSource)));
-            }
-
-            return Task.WhenAll(tasks);
-        }
-
-        async Task Query(NpgsqlDataSource dataSource)
-        {
-            await using var conn = dataSource.CreateConnection();
-            for (var i = 0; i < 5; i++)
-            {
-                await conn.OpenAsync();
-                await conn.ExecuteNonQueryAsync("SELECT 1");
-                await conn.CloseAsync();
-                Interlocked.Increment(ref queriesDone);
-            }
-        }
-    }
-
-    [Test]
-    [IssueLink("https://github.com/npgsql/npgsql/issues/5055")]
-    [NonParallelizable] // Disables sql rewriting
-    public async Task Multiple_hosts_with_disabled_sql_rewriting()
-    {
-        using var _ = DisableSqlRewriting();
-
-        var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
-        {
-            ConnectionStringBuilder =
-            {
-                Host = "localhost,127.0.0.1",
-                Pooling = true,
-                HostRecheckSeconds = 0
-            }
-        };
-        await using var dataSource = dataSourceBuilder.BuildMultiHost();
-        await using var conn = await dataSource.OpenConnectionAsync();
-    }
-
-    [Test]
-    public async Task DataSource_with_wrappers()
-    {
-        await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
-        await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
-
-        var builder = new NpgsqlDataSourceBuilder
-        {
-            ConnectionStringBuilder =
-            {
-                Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
-                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            }
-        };
-
-        await using var dataSource = builder.BuildMultiHost();
-        await using var primaryDataSource = dataSource.WithTargetSession(TargetSessionAttributes.Primary);
-        await using var standbyDataSource = dataSource.WithTargetSession(TargetSessionAttributes.Standby);
-
-        await using var primaryConnection = await primaryDataSource.OpenConnectionAsync();
-        Assert.That(primaryConnection.Port, Is.EqualTo(primaryPostmasterMock.Port));
-
-        await using var standbyConnection = await standbyDataSource.OpenConnectionAsync();
-        Assert.That(standbyConnection.Port, Is.EqualTo(standbyPostmasterMock.Port));
-    }
-
-    [Test]
-    public async Task DataSource_without_wrappers()
-    {
-        await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
-        await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
-
-        var builder = new NpgsqlDataSourceBuilder
-        {
-            ConnectionStringBuilder =
-            {
-                Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
-                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            }
-        };
-
-        await using var dataSource = builder.BuildMultiHost();
-
-        await using var primaryConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Primary);
-        Assert.That(primaryConnection.Port, Is.EqualTo(primaryPostmasterMock.Port));
-
-        await using var standbyConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Standby);
-        Assert.That(standbyConnection.Port, Is.EqualTo(standbyPostmasterMock.Port));
-    }
-
-    [Test]
-    public void DataSource_with_TargetSessionAttributes_is_not_supported()
-    {
-        var builder = new NpgsqlDataSourceBuilder("Host=foo,bar;Target Session Attributes=primary");
-
-        Assert.That(() => builder.BuildMultiHost(), Throws.Exception.TypeOf<InvalidOperationException>()
-            .With.Message.EqualTo(NpgsqlStrings.CannotSpecifyTargetSessionAttributes));
-    }
-
-    [Test]
-    public async Task BuildMultiHost_with_single_host_is_supported()
-    {
-        var builder = new NpgsqlDataSourceBuilder(ConnectionString);
-        await using var dataSource = builder.BuildMultiHost();
-        await using var connection = await dataSource.OpenConnectionAsync();
-        Assert.That(await connection.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
-    }
-
-    [Test]
-    public async Task Build_with_multiple_hosts_is_supported()
-    {
-        await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
-        await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
-
-        var builder = new NpgsqlDataSourceBuilder
-        {
-            ConnectionStringBuilder =
-            {
-                Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
-                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-            }
-        };
-
-        await using var dataSource = builder.Build();
-        await using var connection = await dataSource.OpenConnectionAsync();
-    }
-
-    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/4181")]
-    [Explicit("Fails until #4181 is fixed.")]
-    public async Task LoadBalancing_is_fair_if_first_host_is_down([Values]TargetSessionAttributes targetSessionAttributes)
-    {
-        await using var pDown = PgPostmasterMock.Start(state: Primary, startupErrorCode: PostgresErrorCodes.CannotConnectNow);
-        await using var pRw1 = PgPostmasterMock.Start(state: Primary);
-        await using var pR1 = PgPostmasterMock.Start(state: PrimaryReadOnly);
-        await using var s1 = PgPostmasterMock.Start(state: Standby);
-        await using var pRw2 = PgPostmasterMock.Start(state: Primary);
-        await using var pR2 = PgPostmasterMock.Start(state: PrimaryReadOnly);
-        await using var s2 = PgPostmasterMock.Start(state: Standby);
-
-        var hostList = $"{pDown.Host}:{pDown.Port}," +
-                       $"{pRw1.Host}:{pRw1.Port}," +
-                       $"{pR1.Host}:{pR1.Port}," +
-                       $"{s1.Host}:{s1.Port}," +
-                       $"{pRw2.Host}:{pRw2.Port}," +
-                       $"{pR2.Host}:{pR2.Port}," +
-                       $"{s2.Host}:{s2.Port}";
-
-        await using var dataSource = CreateDataSource(builder =>
-        {
-            builder.Host = hostList;
-            builder.ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading;
-            builder.LoadBalanceHosts = true;
-            builder.TargetSessionAttributesParsed = targetSessionAttributes;
-
-        });
-        var connections = Enumerable.Repeat(0, 12).Select(_ => dataSource.OpenConnection()).ToArray();
-        await using var __ = new DisposableWrapper(connections);
-
-        switch (targetSessionAttributes)
-        {
-        case TargetSessionAttributes.Any:
-            Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[1].Port, Is.EqualTo(pR1.Port));
-            Assert.That(connections[2].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[3].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[4].Port, Is.EqualTo(pR2.Port));
-            Assert.That(connections[5].Port, Is.EqualTo(s2.Port));
-            Assert.That(connections[6].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[7].Port, Is.EqualTo(pR1.Port));
-            Assert.That(connections[8].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[9].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[10].Port, Is.EqualTo(pR2.Port));
-            Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
-            break;
-        case TargetSessionAttributes.ReadWrite:
-            Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[1].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[2].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[3].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[4].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[5].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[6].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[7].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[8].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[9].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[10].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[11].Port, Is.EqualTo(pRw2.Port));
-            break;
-        case TargetSessionAttributes.ReadOnly:
-            Assert.That(connections[0].Port, Is.EqualTo(pR1.Port));
-            Assert.That(connections[1].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[2].Port, Is.EqualTo(pR2.Port));
-            Assert.That(connections[3].Port, Is.EqualTo(s2.Port));
-            Assert.That(connections[4].Port, Is.EqualTo(pR1.Port));
-            Assert.That(connections[5].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[6].Port, Is.EqualTo(pR2.Port));
-            Assert.That(connections[7].Port, Is.EqualTo(s2.Port));
-            Assert.That(connections[8].Port, Is.EqualTo(pR1.Port));
-            Assert.That(connections[9].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[10].Port, Is.EqualTo(pR2.Port));
-            Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
-            break;
-        case TargetSessionAttributes.Primary:
-        case TargetSessionAttributes.PreferPrimary:
-            Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[1].Port, Is.EqualTo(pR1.Port));
-            Assert.That(connections[2].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[3].Port, Is.EqualTo(pR2.Port));
-            Assert.That(connections[4].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[5].Port, Is.EqualTo(pR1.Port));
-            Assert.That(connections[6].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[7].Port, Is.EqualTo(pR2.Port));
-            Assert.That(connections[8].Port, Is.EqualTo(pRw1.Port));
-            Assert.That(connections[9].Port, Is.EqualTo(pR1.Port));
-            Assert.That(connections[10].Port, Is.EqualTo(pRw2.Port));
-            Assert.That(connections[11].Port, Is.EqualTo(pR2.Port));
-            break;
-        case TargetSessionAttributes.Standby:
-        case TargetSessionAttributes.PreferStandby:
-            Assert.That(connections[0].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[1].Port, Is.EqualTo(s2.Port));
-            Assert.That(connections[2].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[3].Port, Is.EqualTo(s2.Port));
-            Assert.That(connections[4].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[5].Port, Is.EqualTo(s2.Port));
-            Assert.That(connections[6].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[7].Port, Is.EqualTo(s2.Port));
-            Assert.That(connections[8].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[9].Port, Is.EqualTo(s2.Port));
-            Assert.That(connections[10].Port, Is.EqualTo(s1.Port));
-            Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
-            break;
-        }
-    }
-
-    static string MultipleHosts(params PgPostmasterMock[] postmasters)
-        => string.Join(",", postmasters.Select(p => $"{p.Host}:{p.Port}"));
-
-    class DisposableWrapper : IAsyncDisposable
-    {
-        readonly IEnumerable<IAsyncDisposable> _disposables;
-
-        public DisposableWrapper(IEnumerable<IAsyncDisposable> disposables) => _disposables = disposables;
-
-        public async ValueTask DisposeAsync()
-        {
-            foreach (var disposable in _disposables)
-                await disposable.DisposeAsync();
-        }
-    }
-}
+﻿// using YBNpgsql.Internal;
+// using YBNpgsql.Tests.Support;
+// using NUnit.Framework;
+// using System;
+// using System.Collections.Generic;
+// using System.Data;
+// using System.IO;
+// using System.Linq;
+// using System.Net;
+// using System.Net.Sockets;
+// using System.Runtime.InteropServices;
+// using System.Threading;
+// using System.Threading.Tasks;
+// using System.Transactions;
+// using YBNpgsql.Properties;
+// using static YBNpgsql.Tests.Support.MockState;
+// using static YBNpgsql.Tests.TestUtil;
+// using IsolationLevel = System.Transactions.IsolationLevel;
+// using TransactionStatus = YBNpgsql.Internal.TransactionStatus;
+//
+// namespace YBNpgsql.Tests;
+//
+// public class MultipleHostsTests : TestBase
+// {
+//     static readonly object[] MyCases =
+//     {
+//         new object[] { TargetSessionAttributes.Standby,        new[] { Primary,         Standby         }, 1 },
+//         new object[] { TargetSessionAttributes.Standby,        new[] { PrimaryReadOnly, Standby         }, 1 },
+//         new object[] { TargetSessionAttributes.PreferStandby,  new[] { Primary,         Standby         }, 1 },
+//         new object[] { TargetSessionAttributes.PreferStandby,  new[] { PrimaryReadOnly, Standby         }, 1 },
+//         new object[] { TargetSessionAttributes.PreferStandby,  new[] { Primary,         Primary         }, 0 },
+//         new object[] { TargetSessionAttributes.Primary,        new[] { Standby,         Primary         }, 1 },
+//         new object[] { TargetSessionAttributes.Primary,        new[] { Standby,         PrimaryReadOnly }, 1 },
+//         new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         Primary         }, 1 },
+//         new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         PrimaryReadOnly }, 1 },
+//         new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         Standby         }, 0 },
+//         new object[] { TargetSessionAttributes.Any,            new[] { Standby,         Primary         }, 0 },
+//         new object[] { TargetSessionAttributes.Any,            new[] { Primary,         Standby         }, 0 },
+//         new object[] { TargetSessionAttributes.Any,            new[] { PrimaryReadOnly, Standby         }, 0 },
+//         new object[] { TargetSessionAttributes.ReadWrite,      new[] { Standby,         Primary         }, 1 },
+//         new object[] { TargetSessionAttributes.ReadWrite,      new[] { PrimaryReadOnly, Primary         }, 1 },
+//         new object[] { TargetSessionAttributes.ReadOnly,       new[] { Primary,         Standby         }, 1 },
+//         new object[] { TargetSessionAttributes.ReadOnly,       new[] { PrimaryReadOnly, Standby         }, 0 }
+//     };
+//
+//     [Test]
+//     [TestCaseSource(nameof(MyCases))]
+//     public async Task Connect_to_correct_host_pooled(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
+//     {
+//         var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+//         await using var __ = new DisposableWrapper(postmasters);
+//
+//         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(postmasters),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             Pooling = true
+//         };
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
+//             .BuildMultiHost();
+//         await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
+//
+//         Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
+//
+//         for (var i = 0; i <= expectedServer; i++)
+//             _ = await postmasters[i].WaitForServerConnection();
+//     }
+//
+//     [Test]
+//     [TestCaseSource(nameof(MyCases))]
+//     public async Task Connect_to_correct_host_unpooled(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
+//     {
+//         var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+//         await using var __ = new DisposableWrapper(postmasters);
+//
+//         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(postmasters),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             Pooling = false
+//         };
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
+//             .BuildMultiHost();
+//         await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
+//
+//         Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
+//
+//         for (var i = 0; i <= expectedServer; i++)
+//             _ = await postmasters[i].WaitForServerConnection();
+//     }
+//
+//     [Test]
+//     [TestCaseSource(nameof(MyCases))]
+//     public async Task Connect_to_correct_host_with_available_idle(
+//         TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
+//     {
+//         var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+//         await using var __ = new DisposableWrapper(postmasters);
+//
+//         // First, open and close a connection with the TargetSessionAttributes matching the first server.
+//         // This ensures wew have an idle connection in the pool.
+//         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(postmasters),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//         };
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
+//             .BuildMultiHost();
+//         var idleConnTargetSessionAttributes = servers[0] switch
+//         {
+//             Primary => TargetSessionAttributes.ReadWrite,
+//             PrimaryReadOnly => TargetSessionAttributes.ReadOnly,
+//             Standby => TargetSessionAttributes.Standby,
+//             _ => throw new ArgumentOutOfRangeException()
+//         };
+//         await using (_ = await dataSource.OpenConnectionAsync(idleConnTargetSessionAttributes))
+//         {
+//             // Do nothing, close to have an idle connection in the pool.
+//         }
+//
+//         // Now connect with the test TargetSessionAttributes
+//
+//         await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
+//
+//         Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
+//
+//         for (var i = 0; i <= expectedServer; i++)
+//             _ = await postmasters[i].WaitForServerConnection();
+//     }
+//
+//     [Test]
+//     [TestCase(TargetSessionAttributes.Standby,   new[] { Primary,         Primary })]
+//     [TestCase(TargetSessionAttributes.Primary,   new[] { Standby,         Standby })]
+//     [TestCase(TargetSessionAttributes.ReadWrite, new[] { PrimaryReadOnly, Standby })]
+//     [TestCase(TargetSessionAttributes.ReadOnly,  new[] { Primary,         Primary })]
+//     public async Task Valid_host_not_found(TargetSessionAttributes targetSessionAttributes, MockState[] servers)
+//     {
+//         var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+//         await using var __ = new DisposableWrapper(postmasters);
+//
+//         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(postmasters),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//         };
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
+//             .BuildMultiHost();
+//
+//         var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await dataSource.OpenConnectionAsync(targetSessionAttributes))!;
+//         Assert.That(exception.Message, Is.EqualTo("No suitable host was found."));
+//         Assert.That(exception.InnerException, Is.Null);
+//
+//         for (var i = 0; i < servers.Length; i++)
+//             _ = await postmasters[i].WaitForServerConnection();
+//     }
+//
+//     [Test, Platform(Exclude = "MacOsX", Reason = "#3786")]
+//     public void All_hosts_are_down()
+//     {
+//         // Different exception raised in .NET Core 3.1, skip (NUnit doesn't seem to support detecting .NET Core versions)
+//         if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Core 3.1"))
+//             return;
+//
+//         var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+//
+//         using var socket1 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+//         socket1.Bind(endpoint);
+//         var localEndPoint1 = (IPEndPoint)socket1.LocalEndPoint!;
+//
+//         using var socket2 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+//         socket2.Bind(endpoint);
+//         var localEndPoint2 = (IPEndPoint)socket2.LocalEndPoint!;
+//
+//         // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
+//
+//         var connectionString = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = $"{localEndPoint1.Address}:{localEndPoint1.Port},{localEndPoint2.Address}:{localEndPoint2.Port}"
+//         }.ConnectionString;
+//         using var dataSource = new NpgsqlDataSourceBuilder(connectionString).BuildMultiHost();
+//
+//         var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any))!;
+//         var aggregateException = (AggregateException)exception.InnerException!;
+//         Assert.That(aggregateException.InnerExceptions, Has.Count.EqualTo(2));
+//
+//         for (var i = 0; i < aggregateException.InnerExceptions.Count; i++)
+//         {
+//             Assert.That(aggregateException.InnerExceptions[i], Is.TypeOf<NpgsqlException>()
+//                 .With.InnerException.TypeOf<SocketException>()
+//                 .With.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(SocketError.ConnectionRefused));
+//         }
+//     }
+//
+//     [Test]
+//     public async Task All_hosts_are_unavailable(
+//         [Values] bool pooling,
+//         [Values(PostgresErrorCodes.InvalidCatalogName, PostgresErrorCodes.CannotConnectNow)] string errorCode)
+//     {
+//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary, startupErrorCode: errorCode);
+//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby, startupErrorCode: errorCode);
+//
+//         var builder = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             Pooling = pooling,
+//         };
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString).BuildMultiHost();
+//
+//         var ex = Assert.ThrowsAsync<PostgresException>(async () => await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any))!;
+//         Assert.That(ex.SqlState, Is.EqualTo(errorCode));
+//     }
+//
+//     [Test]
+//     [Platform(Exclude = "MacOsX", Reason = "Flaky in CI on Mac")]
+//     public async Task First_host_is_down()
+//     {
+//         using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+//         var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+//         socket.Bind(endpoint);
+//         var localEndPoint = (IPEndPoint)socket.LocalEndPoint!;
+//         // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
+//
+//         await using var postmaster = PgPostmasterMock.Start(state: Primary);
+//
+//         var connectionString = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = $"{localEndPoint.Address}:{localEndPoint.Port},{postmaster.Host}:{postmaster.Port}",
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
+//         }.ConnectionString;
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionString).BuildMultiHost();
+//
+//         await using var conn = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any);
+//         Assert.That(conn.Port, Is.EqualTo(postmaster.Port));
+//     }
+//
+//     [Test]
+//     [TestCase("any")]
+//     [TestCase("primary")]
+//     [TestCase("standby")]
+//     [TestCase("prefer-primary")]
+//     [TestCase("prefer-standby")]
+//     [TestCase("read-write")]
+//     [TestCase("read-only")]
+//     public async Task TargetSessionAttributes_with_single_host(string targetSessionAttributes)
+//     {
+//         var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
+//         {
+//             TargetSessionAttributes = targetSessionAttributes
+//         }.ConnectionString;
+//
+//         if (targetSessionAttributes == "any")
+//         {
+//             await using var postmasterMock = PgPostmasterMock.Start(ConnectionString);
+//             using var pool = CreateTempPool(postmasterMock.ConnectionString, out connectionString);
+//             await using var conn = new NpgsqlConnection(connectionString);
+//             await conn.OpenAsync();
+//             _ = await postmasterMock.WaitForServerConnection();
+//         }
+//         else
+//         {
+//             Assert.That(() => new NpgsqlConnection(connectionString), Throws.Exception.TypeOf<NotSupportedException>());
+//         }
+//     }
+//
+//     [Test]
+//     public void TargetSessionAttributes_default_is_null()
+//         => Assert.That(new NpgsqlConnectionStringBuilder().TargetSessionAttributes, Is.Null);
+//
+//     [Test]
+//     [NonParallelizable] // Sets environment variable
+//     public async Task TargetSessionAttributes_uses_environment_variable()
+//     {
+//         using var envVarResetter = SetEnvironmentVariable("PGTARGETSESSIONATTRS", "prefer-standby");
+//
+//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+//
+//         var builder = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
+//         };
+//
+//         Assert.That(builder.TargetSessionAttributes, Is.Null);
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString)
+//             .BuildMultiHost();
+//
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//         Assert.That(conn.Port, Is.EqualTo(standbyPostmaster.Port));
+//     }
+//
+//     [Test]
+//     public void TargetSessionAttributes_invalid_throws()
+//         => Assert.Throws<ArgumentException>(() =>
+//             new NpgsqlConnectionStringBuilder
+//             {
+//                 TargetSessionAttributes = nameof(TargetSessionAttributes_invalid_throws)
+//             });
+//
+//     [Test]
+//     public void HostRecheckSeconds_default_value()
+//     {
+//         var builder = new NpgsqlConnectionStringBuilder();
+//         Assert.That(builder.HostRecheckSeconds, Is.EqualTo(10));
+//         Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(10)));
+//     }
+//
+//     [Test]
+//     public void HostRecheckSeconds_zero_value()
+//     {
+//         var builder = new NpgsqlConnectionStringBuilder
+//         {
+//             HostRecheckSeconds = 0,
+//         };
+//         Assert.That(builder.HostRecheckSeconds, Is.EqualTo(0));
+//         Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(-1)));
+//     }
+//
+//     [Test]
+//     public void HostRecheckSeconds_invalid_throws()
+//         => Assert.Throws<ArgumentException>(() =>
+//             new NpgsqlConnectionStringBuilder
+//             {
+//                 HostRecheckSeconds = -1
+//             });
+//
+//     [Test]
+//     public async Task Connect_with_load_balancing()
+//     {
+//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+//
+//         var defaultCsb = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             MaxPoolSize = 1,
+//             LoadBalanceHosts = true,
+//         };
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
+//             .BuildMultiHost();
+//
+//         NpgsqlConnector firstConnector;
+//         NpgsqlConnector secondConnector;
+//
+//         await using (var firstConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             firstConnector = firstConnection.Connector!;
+//         }
+//
+//         await using (var secondConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             secondConnector = secondConnection.Connector!;
+//         }
+//
+//         Assert.AreNotSame(firstConnector, secondConnector);
+//
+//         await using (var firstBalancedConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             Assert.AreSame(firstConnector, firstBalancedConnection.Connector);
+//         }
+//
+//         await using (var secondBalancedConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             Assert.AreSame(secondConnector, secondBalancedConnection.Connector);
+//         }
+//
+//         await using (var thirdBalancedConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             Assert.AreSame(firstConnector, thirdBalancedConnection.Connector);
+//         }
+//     }
+//
+//     [Test]
+//     public async Task Connect_without_load_balancing()
+//     {
+//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+//
+//         var defaultCsb = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             MaxPoolSize = 1,
+//             LoadBalanceHosts = false,
+//         };
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
+//             .BuildMultiHost();
+//
+//         NpgsqlConnector firstConnector;
+//         NpgsqlConnector secondConnector;
+//
+//         await using (var firstConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             firstConnector = firstConnection.Connector!;
+//         }
+//         await using (var secondConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             Assert.AreSame(firstConnector, secondConnection.Connector);
+//         }
+//         await using (var firstConnection = await dataSource.OpenConnectionAsync())
+//         await using (var secondConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             secondConnector = secondConnection.Connector!;
+//         }
+//
+//         Assert.AreNotSame(firstConnector, secondConnector);
+//
+//         await using (var firstUnbalancedConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             Assert.AreSame(firstConnector, firstUnbalancedConnection.Connector);
+//         }
+//
+//         await using (var secondUnbalancedConnection = await dataSource.OpenConnectionAsync())
+//         {
+//             Assert.AreSame(firstConnector, secondUnbalancedConnection.Connector);
+//         }
+//     }
+//
+//     [Test]
+//     public async Task Connect_state_changing_hosts([Values] bool alwaysCheckHostState)
+//     {
+//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+//
+//         var defaultCsb = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             MaxPoolSize = 1,
+//             HostRecheckSeconds = alwaysCheckHostState ? 0 : int.MaxValue,
+//             NoResetOnClose = true,
+//         };
+//
+//         await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
+//             .BuildMultiHost();
+//
+//         NpgsqlConnector firstConnector;
+//         NpgsqlConnector secondConnector;
+//         var firstServerTask = Task.Run(async () =>
+//         {
+//             var server = await primaryPostmaster.WaitForServerConnection();
+//             if (!alwaysCheckHostState)
+//                 return;
+//
+//             // If we always check the host, we will send the request for the state
+//             // even though we got one while opening the connection
+//             await server.SendMockState(Primary);
+//
+//             // Update the state after a 'failover'
+//             await server.SendMockState(Standby);
+//         });
+//         var secondServerTask = Task.Run(async () =>
+//         {
+//             var server = await standbyPostmaster.WaitForServerConnection();
+//             if (!alwaysCheckHostState)
+//                 return;
+//
+//             // If we always check the host, we will send the request for the state
+//             // even though we got one while opening the connection
+//             await server.SendMockState(Standby);
+//
+//             // As TargetSessionAttributes is 'prefer', it does another cycle for the 'unpreferred'
+//             await server.SendMockState(Standby);
+//             // Update the state after a 'failover'
+//             await server.SendMockState(Primary);
+//         });
+//
+//         await using (var firstConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary))
+//         await using (var secondConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary))
+//         {
+//             firstConnector = firstConnection.Connector!;
+//             secondConnector = secondConnection.Connector!;
+//         }
+//
+//         await using var thirdConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary);
+//         Assert.AreSame(alwaysCheckHostState ? secondConnector : firstConnector, thirdConnection.Connector);
+//
+//         await firstServerTask;
+//         await secondServerTask;
+//     }
+//
+//     [Test]
+//     public void Database_state_cache_basic()
+//     {
+//         using var dataSource = CreateDataSource();
+//         var timeStamp = DateTime.UtcNow;
+//
+//         dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadWrite, timeStamp, TimeSpan.Zero);
+//         Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState());
+//
+//         // Update with the same timestamp - shouldn't change anything
+//         dataSource.UpdateDatabaseState(DatabaseState.Standby, timeStamp, TimeSpan.Zero);
+//         Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState());
+//
+//         // Update with a new timestamp
+//         timeStamp = timeStamp.AddSeconds(1);
+//         dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadOnly, timeStamp, TimeSpan.Zero);
+//         Assert.AreEqual(DatabaseState.PrimaryReadOnly, dataSource.GetDatabaseState());
+//
+//         // Expired state returns as Unknown (depending on ignoreExpiration)
+//         timeStamp = timeStamp.AddSeconds(1);
+//         dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadWrite, timeStamp, TimeSpan.FromSeconds(-1));
+//         Assert.AreEqual(DatabaseState.Unknown, dataSource.GetDatabaseState(ignoreExpiration: false));
+//         Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState(ignoreExpiration: true));
+//     }
+//
+//     [Test]
+//     public async Task Offline_state_on_connection_failure()
+//     {
+//         await using var server = PgPostmasterMock.Start(ConnectionString, startupErrorCode: PostgresErrorCodes.ConnectionFailure);
+//         await using var dataSource = server.CreateDataSource();
+//         await using var conn = dataSource.CreateConnection();
+//
+//         var ex = Assert.ThrowsAsync<PostgresException>(conn.OpenAsync)!;
+//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.ConnectionFailure));
+//
+//         var state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Offline));
+//     }
+//
+//     [Test]
+//     public async Task Unknown_state_on_connection_authentication_failure()
+//     {
+//         await using var server = PgPostmasterMock.Start(ConnectionString, startupErrorCode: PostgresErrorCodes.InvalidAuthorizationSpecification);
+//         await using var dataSource = server.CreateDataSource();
+//         await using var conn = dataSource.CreateConnection();
+//
+//         var ex = Assert.ThrowsAsync<PostgresException>(conn.OpenAsync)!;
+//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.InvalidAuthorizationSpecification));
+//
+//         var state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//     }
+//
+//     [Test]
+//     public async Task Offline_state_on_query_execution_pg_critical_failure()
+//     {
+//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+//         await using var dataSource = postmaster.CreateDataSource();
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//         await using var anotherConn = await dataSource.OpenConnectionAsync();
+//         await anotherConn.CloseAsync();
+//
+//         var state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+//
+//         var server = await postmaster.WaitForServerConnection();
+//         await server.WriteErrorResponse(PostgresErrorCodes.CrashShutdown).FlushAsync();
+//
+//         var ex = Assert.ThrowsAsync<PostgresException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
+//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.CrashShutdown));
+//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+//
+//         state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Offline));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
+//     }
+//
+//     [Test, NonParallelizable]
+//     public async Task Offline_state_on_query_execution_pg_non_critical_failure()
+//     {
+//         await using var dataSource = CreateDataSource();
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//
+//         // Starting with PG14 we get the cluster's state from PG automatically
+//         var expectedState = conn.PostgreSqlVersion.Major > 13 ? DatabaseState.PrimaryReadWrite : DatabaseState.Unknown;
+//
+//         var state = dataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(expectedState));
+//         Assert.That(dataSource.Statistics.Total, Is.EqualTo(1));
+//
+//         var ex = Assert.ThrowsAsync<PostgresException>(() => conn.ExecuteNonQueryAsync("SELECT abc"))!;
+//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.UndefinedColumn));
+//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
+//
+//         state = dataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(expectedState));
+//         Assert.That(dataSource.Statistics.Total, Is.EqualTo(1));
+//     }
+//
+//     [Test]
+//     public async Task Offline_state_on_query_execution_IOException()
+//     {
+//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+//         await using var dataSource = postmaster.CreateDataSource();
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//         await using var anotherConn = await dataSource.OpenConnectionAsync();
+//         await anotherConn.CloseAsync();
+//
+//         var state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+//
+//         var server = await postmaster.WaitForServerConnection();
+//         server.Close();
+//
+//         var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
+//         Assert.That(ex.InnerException, Is.InstanceOf<IOException>());
+//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+//
+//         state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Offline));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
+//     }
+//
+//     [Test]
+//     public async Task Offline_state_on_query_execution_TimeoutException()
+//     {
+//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+//         var dataSourceBuilder = postmaster.GetDataSourceBuilder();
+//         dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
+//         dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = 1;
+//         await using var dataSource = dataSourceBuilder.Build();
+//
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//         await using var anotherConn = await dataSource.OpenConnectionAsync();
+//         await anotherConn.CloseAsync();
+//
+//         var state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+//
+//         var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
+//         Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+//
+//         state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Offline));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
+//     }
+//
+//     [Test]
+//     public async Task Unknown_state_on_query_execution_TimeoutException_with_disabled_cancellation()
+//     {
+//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+//         var dataSourceBuilder = postmaster.GetDataSourceBuilder();
+//         dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
+//         dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = -1;
+//         await using var dataSource = dataSourceBuilder.Build();
+//
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//         await using var anotherConn = await dataSource.OpenConnectionAsync();
+//         await anotherConn.CloseAsync();
+//
+//         var state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+//
+//         var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
+//         Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+//
+//         state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+//     }
+//
+//     [Test]
+//     public async Task Unknown_state_on_query_execution_cancellation_with_disabled_cancellation_timeout()
+//     {
+//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+//         var dataSourceBuilder = postmaster.GetDataSourceBuilder();
+//         dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 30;
+//         dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = -1;
+//         await using var dataSource = dataSourceBuilder.Build();
+//
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//         await using var anotherConn = await dataSource.OpenConnectionAsync();
+//         await anotherConn.CloseAsync();
+//
+//         var state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+//
+//         using var cts = new CancellationTokenSource();
+//
+//         var query = conn.ExecuteNonQueryAsync("SELECT 1", cancellationToken: cts.Token);
+//         cts.Cancel();
+//         var ex = Assert.ThrowsAsync<OperationCanceledException>(async () => await query)!;
+//         Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+//
+//         state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+//     }
+//
+//     [Test]
+//     public async Task Unknown_state_on_query_execution_TimeoutException_with_cancellation_failure()
+//     {
+//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+//         var dataSourceBuilder = postmaster.GetDataSourceBuilder();
+//         dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
+//         dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = 0;
+//         await using var dataSource = dataSourceBuilder.Build();
+//
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//
+//         var state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+//
+//         var server = await postmaster.WaitForServerConnection();
+//
+//         var query = conn.ExecuteNonQueryAsync("SELECT 1");
+//
+//         await postmaster.WaitForCancellationRequest();
+//         await server.WriteCancellationResponse().WriteReadyForQuery().FlushAsync();
+//
+//         var ex = Assert.ThrowsAsync<NpgsqlException>(async () => await query)!;
+//         Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
+//
+//         state = conn.NpgsqlDataSource.GetDatabaseState();
+//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+//     }
+//
+//     [Test]
+//     public async Task Clear_pool_one_host_only_on_admin_shutdown()
+//     {
+//         await using var primaryPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
+//         await using var standbyPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
+//         var dataSourceBuilder = new NpgsqlDataSourceBuilder
+//         {
+//             ConnectionStringBuilder =
+//             {
+//                 Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//                 MaxPoolSize = 2
+//             }
+//         };
+//         await using var multiHostDataSource = dataSourceBuilder.BuildMultiHost();
+//         await using var preferPrimaryDataSource = multiHostDataSource.WithTargetSession(TargetSessionAttributes.PreferPrimary);
+//
+//         await using var primaryConn = await preferPrimaryDataSource.OpenConnectionAsync();
+//         await using var anotherPrimaryConn = await preferPrimaryDataSource.OpenConnectionAsync();
+//         await using var standbyConn = await preferPrimaryDataSource.OpenConnectionAsync();
+//         var primaryDataSource = primaryConn.Connector!.DataSource;
+//         var standbyDataSource = standbyConn.Connector!.DataSource;
+//         await anotherPrimaryConn.CloseAsync();
+//         await standbyConn.CloseAsync();
+//
+//         Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.PrimaryReadWrite));
+//         Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
+//         Assert.That(primaryConn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(3));
+//
+//         var server = await primaryPostmaster.WaitForServerConnection();
+//         await server.WriteErrorResponse(PostgresErrorCodes.AdminShutdown).FlushAsync();
+//
+//         var ex = Assert.ThrowsAsync<PostgresException>(() => primaryConn.ExecuteNonQueryAsync("SELECT 1"))!;
+//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.AdminShutdown));
+//         Assert.That(primaryConn.State, Is.EqualTo(ConnectionState.Closed));
+//
+//         Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Offline));
+//         Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
+//         Assert.That(primaryConn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+//
+//         multiHostDataSource.ClearDatabaseStates();
+//         Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
+//     }
+//
+//     [Test]
+//     [TestCase("any", true)]
+//     [TestCase("primary", true)]
+//     [TestCase("standby", false)]
+//     [TestCase("prefer-primary", true)]
+//     [TestCase("prefer-standby", false)]
+//     [TestCase("read-write", true)]
+//     [TestCase("read-only", false)]
+//     public async Task Transaction_enlist_reuses_connection(string targetSessionAttributes, bool primary)
+//     {
+//         await using var primaryPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
+//         await using var standbyPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
+//         var csb = new NpgsqlConnectionStringBuilder
+//         {
+//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+//             TargetSessionAttributes = targetSessionAttributes,
+//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             MaxPoolSize = 10,
+//         };
+//
+//         using var _ = CreateTempPool(csb, out var connString);
+//
+//         using var scope = new TransactionScope(TransactionScopeOption.Required,
+//             new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }, TransactionScopeAsyncFlowOption.Enabled);
+//
+//         var query1Task = Query(connString);
+//
+//         var server = primary
+//             ? await primaryPostmaster.WaitForServerConnection()
+//             : await standbyPostmaster.WaitForServerConnection();
+//
+//         await server
+//             .WriteCommandComplete()
+//             .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
+//             .WriteParseComplete()
+//             .WriteBindComplete()
+//             .WriteNoData()
+//             .WriteCommandComplete()
+//             .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
+//             .FlushAsync();
+//         await query1Task;
+//
+//         var query2Task = Query(connString);
+//         await server
+//             .WriteParseComplete()
+//             .WriteBindComplete()
+//             .WriteNoData()
+//             .WriteCommandComplete()
+//             .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
+//             .FlushAsync();
+//         await query2Task;
+//
+//         await server
+//             .WriteCommandComplete()
+//             .WriteReadyForQuery()
+//             .FlushAsync();
+//         scope.Complete();
+//
+//         async Task Query(string connectionString)
+//         {
+//             await using var conn = new NpgsqlConnection(connectionString);
+//             await conn.OpenAsync();
+//
+//             await using var cmd = conn.CreateCommand();
+//             cmd.CommandText = "SELECT 1";
+//             await cmd.ExecuteNonQueryAsync();
+//         }
+//     }
+//
+//     [Test]
+//     public async Task Primary_host_failover_can_connect()
+//     {
+//         await using var firstPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
+//         await using var secondPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
+//         var dataSourceBuilder = new NpgsqlDataSourceBuilder
+//         {
+//             ConnectionStringBuilder =
+//             {
+//                 Host = MultipleHosts(firstPostmaster, secondPostmaster),
+//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//                 HostRecheckSeconds = 5
+//             }
+//         };
+//         await using var multiHostDataSource = dataSourceBuilder.BuildMultiHost();
+//         var (firstDataSource, secondDataSource) = (multiHostDataSource.Pools[0], multiHostDataSource.Pools[1]);
+//         await using var primaryDataSource = multiHostDataSource.WithTargetSession(TargetSessionAttributes.Primary);
+//
+//         await using var conn = await primaryDataSource.OpenConnectionAsync();
+//         Assert.That(conn.Port, Is.EqualTo(firstPostmaster.Port));
+//         var firstServer = await firstPostmaster.WaitForServerConnection();
+//         await firstServer
+//             .WriteErrorResponse(PostgresErrorCodes.AdminShutdown)
+//             .FlushAsync();
+//
+//         var failoverEx = Assert.ThrowsAsync<PostgresException>(async () => await conn.ExecuteNonQueryAsync("SELECT 1"))!;
+//         Assert.That(failoverEx.SqlState, Is.EqualTo(PostgresErrorCodes.AdminShutdown));
+//
+//         var noHostFoundEx = Assert.ThrowsAsync<NpgsqlException>(async () => await conn.OpenAsync())!;
+//         Assert.That(noHostFoundEx.Message, Is.EqualTo("No suitable host was found."));
+//
+//         Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Offline));
+//         Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
+//
+//         firstPostmaster.State = Standby;
+//         secondPostmaster.State = Primary;
+//         var secondServer = await secondPostmaster.WaitForServerConnection();
+//         await secondServer.SendMockState(Primary);
+//
+//         await Task.Delay(TimeSpan.FromSeconds(10));
+//         Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
+//         Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
+//
+//         await conn.OpenAsync();
+//         Assert.That(conn.Port, Is.EqualTo(secondPostmaster.Port));
+//         Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
+//         Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.PrimaryReadWrite));
+//     }
+//
+//     [Test, NonParallelizable]
+//     public void IntegrationTest([Values] bool loadBalancing, [Values] bool alwaysCheckHostState)
+//     {
+//         PoolManager.Reset();
+//
+//         var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
+//         {
+//             ConnectionStringBuilder =
+//             {
+//                 Host = "localhost,127.0.0.1",
+//                 Pooling = true,
+//                 MaxPoolSize = 2,
+//                 LoadBalanceHosts = loadBalancing,
+//                 HostRecheckSeconds = alwaysCheckHostState ? 0 : 10,
+//             }
+//         };
+//         using var dataSource = dataSourceBuilder.BuildMultiHost();
+//
+//         var queriesDone = 0;
+//
+//         var clientsTask = Task.WhenAll(
+//             Client(dataSource, TargetSessionAttributes.Any),
+//             Client(dataSource, TargetSessionAttributes.Primary),
+//             Client(dataSource, TargetSessionAttributes.PreferPrimary),
+//             Client(dataSource, TargetSessionAttributes.PreferStandby),
+//             Client(dataSource, TargetSessionAttributes.ReadWrite));
+//
+//         var onlyStandbyClient = Client(dataSource, TargetSessionAttributes.Standby);
+//         var readOnlyClient = Client(dataSource, TargetSessionAttributes.ReadOnly);
+//
+//         Assert.DoesNotThrowAsync(() => clientsTask);
+//         Assert.ThrowsAsync<NpgsqlException>(() => onlyStandbyClient);
+//         Assert.ThrowsAsync<NpgsqlException>(() => readOnlyClient);
+//         Assert.AreEqual(125, queriesDone);
+//
+//         Task Client(NpgsqlMultiHostDataSource multiHostDataSource, TargetSessionAttributes targetSessionAttributes)
+//         {
+//             var dataSource = multiHostDataSource.WithTargetSession(targetSessionAttributes);
+//             var tasks = new List<Task>(5);
+//
+//             for (var i = 0; i < 5; i++)
+//             {
+//                 tasks.Add(Task.Run(() => Query(dataSource)));
+//             }
+//
+//             return Task.WhenAll(tasks);
+//         }
+//
+//         async Task Query(NpgsqlDataSource dataSource)
+//         {
+//             await using var conn = dataSource.CreateConnection();
+//             for (var i = 0; i < 5; i++)
+//             {
+//                 await conn.OpenAsync();
+//                 await conn.ExecuteNonQueryAsync("SELECT 1");
+//                 await conn.CloseAsync();
+//                 Interlocked.Increment(ref queriesDone);
+//             }
+//         }
+//     }
+//
+//     [Test]
+//     [IssueLink("https://github.com/npgsql/npgsql/issues/5055")]
+//     [NonParallelizable] // Disables sql rewriting
+//     public async Task Multiple_hosts_with_disabled_sql_rewriting()
+//     {
+//         using var _ = DisableSqlRewriting();
+//
+//         var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
+//         {
+//             ConnectionStringBuilder =
+//             {
+//                 Host = "localhost,127.0.0.1",
+//                 Pooling = true,
+//                 HostRecheckSeconds = 0
+//             }
+//         };
+//         await using var dataSource = dataSourceBuilder.BuildMultiHost();
+//         await using var conn = await dataSource.OpenConnectionAsync();
+//     }
+//
+//     [Test]
+//     public async Task DataSource_with_wrappers()
+//     {
+//         await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
+//         await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
+//
+//         var builder = new NpgsqlDataSourceBuilder
+//         {
+//             ConnectionStringBuilder =
+//             {
+//                 Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
+//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             }
+//         };
+//
+//         await using var dataSource = builder.BuildMultiHost();
+//         await using var primaryDataSource = dataSource.WithTargetSession(TargetSessionAttributes.Primary);
+//         await using var standbyDataSource = dataSource.WithTargetSession(TargetSessionAttributes.Standby);
+//
+//         await using var primaryConnection = await primaryDataSource.OpenConnectionAsync();
+//         Assert.That(primaryConnection.Port, Is.EqualTo(primaryPostmasterMock.Port));
+//
+//         await using var standbyConnection = await standbyDataSource.OpenConnectionAsync();
+//         Assert.That(standbyConnection.Port, Is.EqualTo(standbyPostmasterMock.Port));
+//     }
+//
+//     [Test]
+//     public async Task DataSource_without_wrappers()
+//     {
+//         await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
+//         await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
+//
+//         var builder = new NpgsqlDataSourceBuilder
+//         {
+//             ConnectionStringBuilder =
+//             {
+//                 Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
+//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             }
+//         };
+//
+//         await using var dataSource = builder.BuildMultiHost();
+//
+//         await using var primaryConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Primary);
+//         Assert.That(primaryConnection.Port, Is.EqualTo(primaryPostmasterMock.Port));
+//
+//         await using var standbyConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Standby);
+//         Assert.That(standbyConnection.Port, Is.EqualTo(standbyPostmasterMock.Port));
+//     }
+//
+//     [Test]
+//     public void DataSource_with_TargetSessionAttributes_is_not_supported()
+//     {
+//         var builder = new NpgsqlDataSourceBuilder("Host=foo,bar;Target Session Attributes=primary");
+//
+//         Assert.That(() => builder.BuildMultiHost(), Throws.Exception.TypeOf<InvalidOperationException>()
+//             .With.Message.EqualTo(NpgsqlStrings.CannotSpecifyTargetSessionAttributes));
+//     }
+//
+//     [Test]
+//     public async Task BuildMultiHost_with_single_host_is_supported()
+//     {
+//         var builder = new NpgsqlDataSourceBuilder(ConnectionString);
+//         await using var dataSource = builder.BuildMultiHost();
+//         await using var connection = await dataSource.OpenConnectionAsync();
+//         Assert.That(await connection.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
+//     }
+//
+//     [Test]
+//     public async Task Build_with_multiple_hosts_is_supported()
+//     {
+//         await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
+//         await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
+//
+//         var builder = new NpgsqlDataSourceBuilder
+//         {
+//             ConnectionStringBuilder =
+//             {
+//                 Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
+//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+//             }
+//         };
+//
+//         await using var dataSource = builder.Build();
+//         await using var connection = await dataSource.OpenConnectionAsync();
+//     }
+//
+//     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/4181")]
+//     [Explicit("Fails until #4181 is fixed.")]
+//     public async Task LoadBalancing_is_fair_if_first_host_is_down([Values]TargetSessionAttributes targetSessionAttributes)
+//     {
+//         await using var pDown = PgPostmasterMock.Start(state: Primary, startupErrorCode: PostgresErrorCodes.CannotConnectNow);
+//         await using var pRw1 = PgPostmasterMock.Start(state: Primary);
+//         await using var pR1 = PgPostmasterMock.Start(state: PrimaryReadOnly);
+//         await using var s1 = PgPostmasterMock.Start(state: Standby);
+//         await using var pRw2 = PgPostmasterMock.Start(state: Primary);
+//         await using var pR2 = PgPostmasterMock.Start(state: PrimaryReadOnly);
+//         await using var s2 = PgPostmasterMock.Start(state: Standby);
+//
+//         var hostList = $"{pDown.Host}:{pDown.Port}," +
+//                        $"{pRw1.Host}:{pRw1.Port}," +
+//                        $"{pR1.Host}:{pR1.Port}," +
+//                        $"{s1.Host}:{s1.Port}," +
+//                        $"{pRw2.Host}:{pRw2.Port}," +
+//                        $"{pR2.Host}:{pR2.Port}," +
+//                        $"{s2.Host}:{s2.Port}";
+//
+//         await using var dataSource = CreateDataSource(builder =>
+//         {
+//             builder.Host = hostList;
+//             builder.ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading;
+//             builder.LoadBalanceHosts = true;
+//             builder.TargetSessionAttributesParsed = targetSessionAttributes;
+//
+//         });
+//         var connections = Enumerable.Repeat(0, 12).Select(_ => dataSource.OpenConnection()).ToArray();
+//         await using var __ = new DisposableWrapper(connections);
+//
+//         switch (targetSessionAttributes)
+//         {
+//         case TargetSessionAttributes.Any:
+//             Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[1].Port, Is.EqualTo(pR1.Port));
+//             Assert.That(connections[2].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[3].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[4].Port, Is.EqualTo(pR2.Port));
+//             Assert.That(connections[5].Port, Is.EqualTo(s2.Port));
+//             Assert.That(connections[6].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[7].Port, Is.EqualTo(pR1.Port));
+//             Assert.That(connections[8].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[9].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[10].Port, Is.EqualTo(pR2.Port));
+//             Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
+//             break;
+//         case TargetSessionAttributes.ReadWrite:
+//             Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[1].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[2].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[3].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[4].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[5].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[6].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[7].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[8].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[9].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[10].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[11].Port, Is.EqualTo(pRw2.Port));
+//             break;
+//         case TargetSessionAttributes.ReadOnly:
+//             Assert.That(connections[0].Port, Is.EqualTo(pR1.Port));
+//             Assert.That(connections[1].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[2].Port, Is.EqualTo(pR2.Port));
+//             Assert.That(connections[3].Port, Is.EqualTo(s2.Port));
+//             Assert.That(connections[4].Port, Is.EqualTo(pR1.Port));
+//             Assert.That(connections[5].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[6].Port, Is.EqualTo(pR2.Port));
+//             Assert.That(connections[7].Port, Is.EqualTo(s2.Port));
+//             Assert.That(connections[8].Port, Is.EqualTo(pR1.Port));
+//             Assert.That(connections[9].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[10].Port, Is.EqualTo(pR2.Port));
+//             Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
+//             break;
+//         case TargetSessionAttributes.Primary:
+//         case TargetSessionAttributes.PreferPrimary:
+//             Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[1].Port, Is.EqualTo(pR1.Port));
+//             Assert.That(connections[2].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[3].Port, Is.EqualTo(pR2.Port));
+//             Assert.That(connections[4].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[5].Port, Is.EqualTo(pR1.Port));
+//             Assert.That(connections[6].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[7].Port, Is.EqualTo(pR2.Port));
+//             Assert.That(connections[8].Port, Is.EqualTo(pRw1.Port));
+//             Assert.That(connections[9].Port, Is.EqualTo(pR1.Port));
+//             Assert.That(connections[10].Port, Is.EqualTo(pRw2.Port));
+//             Assert.That(connections[11].Port, Is.EqualTo(pR2.Port));
+//             break;
+//         case TargetSessionAttributes.Standby:
+//         case TargetSessionAttributes.PreferStandby:
+//             Assert.That(connections[0].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[1].Port, Is.EqualTo(s2.Port));
+//             Assert.That(connections[2].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[3].Port, Is.EqualTo(s2.Port));
+//             Assert.That(connections[4].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[5].Port, Is.EqualTo(s2.Port));
+//             Assert.That(connections[6].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[7].Port, Is.EqualTo(s2.Port));
+//             Assert.That(connections[8].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[9].Port, Is.EqualTo(s2.Port));
+//             Assert.That(connections[10].Port, Is.EqualTo(s1.Port));
+//             Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
+//             break;
+//         }
+//     }
+//
+//     static string MultipleHosts(params PgPostmasterMock[] postmasters)
+//         => string.Join(",", postmasters.Select(p => $"{p.Host}:{p.Port}"));
+//
+//     class DisposableWrapper : IAsyncDisposable
+//     {
+//         readonly IEnumerable<IAsyncDisposable> _disposables;
+//
+//         public DisposableWrapper(IEnumerable<IAsyncDisposable> disposables) => _disposables = disposables;
+//
+//         public async ValueTask DisposeAsync()
+//         {
+//             foreach (var disposable in _disposables)
+//                 await disposable.DisposeAsync();
+//         }
+//     }
+// }

--- a/test/Npgsql.Tests/MultipleHostsTests.cs
+++ b/test/Npgsql.Tests/MultipleHostsTests.cs
@@ -1,1185 +1,1185 @@
-﻿// using YBNpgsql.Internal;
-// using YBNpgsql.Tests.Support;
-// using NUnit.Framework;
-// using System;
-// using System.Collections.Generic;
-// using System.Data;
-// using System.IO;
-// using System.Linq;
-// using System.Net;
-// using System.Net.Sockets;
-// using System.Runtime.InteropServices;
-// using System.Threading;
-// using System.Threading.Tasks;
-// using System.Transactions;
-// using YBNpgsql.Properties;
-// using static YBNpgsql.Tests.Support.MockState;
-// using static YBNpgsql.Tests.TestUtil;
-// using IsolationLevel = System.Transactions.IsolationLevel;
-// using TransactionStatus = YBNpgsql.Internal.TransactionStatus;
-//
-// namespace YBNpgsql.Tests;
-//
-// public class MultipleHostsTests : TestBase
-// {
-//     static readonly object[] MyCases =
-//     {
-//         new object[] { TargetSessionAttributes.Standby,        new[] { Primary,         Standby         }, 1 },
-//         new object[] { TargetSessionAttributes.Standby,        new[] { PrimaryReadOnly, Standby         }, 1 },
-//         new object[] { TargetSessionAttributes.PreferStandby,  new[] { Primary,         Standby         }, 1 },
-//         new object[] { TargetSessionAttributes.PreferStandby,  new[] { PrimaryReadOnly, Standby         }, 1 },
-//         new object[] { TargetSessionAttributes.PreferStandby,  new[] { Primary,         Primary         }, 0 },
-//         new object[] { TargetSessionAttributes.Primary,        new[] { Standby,         Primary         }, 1 },
-//         new object[] { TargetSessionAttributes.Primary,        new[] { Standby,         PrimaryReadOnly }, 1 },
-//         new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         Primary         }, 1 },
-//         new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         PrimaryReadOnly }, 1 },
-//         new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         Standby         }, 0 },
-//         new object[] { TargetSessionAttributes.Any,            new[] { Standby,         Primary         }, 0 },
-//         new object[] { TargetSessionAttributes.Any,            new[] { Primary,         Standby         }, 0 },
-//         new object[] { TargetSessionAttributes.Any,            new[] { PrimaryReadOnly, Standby         }, 0 },
-//         new object[] { TargetSessionAttributes.ReadWrite,      new[] { Standby,         Primary         }, 1 },
-//         new object[] { TargetSessionAttributes.ReadWrite,      new[] { PrimaryReadOnly, Primary         }, 1 },
-//         new object[] { TargetSessionAttributes.ReadOnly,       new[] { Primary,         Standby         }, 1 },
-//         new object[] { TargetSessionAttributes.ReadOnly,       new[] { PrimaryReadOnly, Standby         }, 0 }
-//     };
-//
-//     [Test]
-//     [TestCaseSource(nameof(MyCases))]
-//     public async Task Connect_to_correct_host_pooled(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
-//     {
-//         var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
-//         await using var __ = new DisposableWrapper(postmasters);
-//
-//         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(postmasters),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             Pooling = true
-//         };
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
-//             .BuildMultiHost();
-//         await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
-//
-//         Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
-//
-//         for (var i = 0; i <= expectedServer; i++)
-//             _ = await postmasters[i].WaitForServerConnection();
-//     }
-//
-//     [Test]
-//     [TestCaseSource(nameof(MyCases))]
-//     public async Task Connect_to_correct_host_unpooled(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
-//     {
-//         var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
-//         await using var __ = new DisposableWrapper(postmasters);
-//
-//         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(postmasters),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             Pooling = false
-//         };
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
-//             .BuildMultiHost();
-//         await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
-//
-//         Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
-//
-//         for (var i = 0; i <= expectedServer; i++)
-//             _ = await postmasters[i].WaitForServerConnection();
-//     }
-//
-//     [Test]
-//     [TestCaseSource(nameof(MyCases))]
-//     public async Task Connect_to_correct_host_with_available_idle(
-//         TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
-//     {
-//         var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
-//         await using var __ = new DisposableWrapper(postmasters);
-//
-//         // First, open and close a connection with the TargetSessionAttributes matching the first server.
-//         // This ensures wew have an idle connection in the pool.
-//         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(postmasters),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//         };
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
-//             .BuildMultiHost();
-//         var idleConnTargetSessionAttributes = servers[0] switch
-//         {
-//             Primary => TargetSessionAttributes.ReadWrite,
-//             PrimaryReadOnly => TargetSessionAttributes.ReadOnly,
-//             Standby => TargetSessionAttributes.Standby,
-//             _ => throw new ArgumentOutOfRangeException()
-//         };
-//         await using (_ = await dataSource.OpenConnectionAsync(idleConnTargetSessionAttributes))
-//         {
-//             // Do nothing, close to have an idle connection in the pool.
-//         }
-//
-//         // Now connect with the test TargetSessionAttributes
-//
-//         await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
-//
-//         Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
-//
-//         for (var i = 0; i <= expectedServer; i++)
-//             _ = await postmasters[i].WaitForServerConnection();
-//     }
-//
-//     [Test]
-//     [TestCase(TargetSessionAttributes.Standby,   new[] { Primary,         Primary })]
-//     [TestCase(TargetSessionAttributes.Primary,   new[] { Standby,         Standby })]
-//     [TestCase(TargetSessionAttributes.ReadWrite, new[] { PrimaryReadOnly, Standby })]
-//     [TestCase(TargetSessionAttributes.ReadOnly,  new[] { Primary,         Primary })]
-//     public async Task Valid_host_not_found(TargetSessionAttributes targetSessionAttributes, MockState[] servers)
-//     {
-//         var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
-//         await using var __ = new DisposableWrapper(postmasters);
-//
-//         var connectionStringBuilder = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(postmasters),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//         };
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
-//             .BuildMultiHost();
-//
-//         var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await dataSource.OpenConnectionAsync(targetSessionAttributes))!;
-//         Assert.That(exception.Message, Is.EqualTo("No suitable host was found."));
-//         Assert.That(exception.InnerException, Is.Null);
-//
-//         for (var i = 0; i < servers.Length; i++)
-//             _ = await postmasters[i].WaitForServerConnection();
-//     }
-//
-//     [Test, Platform(Exclude = "MacOsX", Reason = "#3786")]
-//     public void All_hosts_are_down()
-//     {
-//         // Different exception raised in .NET Core 3.1, skip (NUnit doesn't seem to support detecting .NET Core versions)
-//         if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Core 3.1"))
-//             return;
-//
-//         var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
-//
-//         using var socket1 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-//         socket1.Bind(endpoint);
-//         var localEndPoint1 = (IPEndPoint)socket1.LocalEndPoint!;
-//
-//         using var socket2 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-//         socket2.Bind(endpoint);
-//         var localEndPoint2 = (IPEndPoint)socket2.LocalEndPoint!;
-//
-//         // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
-//
-//         var connectionString = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = $"{localEndPoint1.Address}:{localEndPoint1.Port},{localEndPoint2.Address}:{localEndPoint2.Port}"
-//         }.ConnectionString;
-//         using var dataSource = new NpgsqlDataSourceBuilder(connectionString).BuildMultiHost();
-//
-//         var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any))!;
-//         var aggregateException = (AggregateException)exception.InnerException!;
-//         Assert.That(aggregateException.InnerExceptions, Has.Count.EqualTo(2));
-//
-//         for (var i = 0; i < aggregateException.InnerExceptions.Count; i++)
-//         {
-//             Assert.That(aggregateException.InnerExceptions[i], Is.TypeOf<NpgsqlException>()
-//                 .With.InnerException.TypeOf<SocketException>()
-//                 .With.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(SocketError.ConnectionRefused));
-//         }
-//     }
-//
-//     [Test]
-//     public async Task All_hosts_are_unavailable(
-//         [Values] bool pooling,
-//         [Values(PostgresErrorCodes.InvalidCatalogName, PostgresErrorCodes.CannotConnectNow)] string errorCode)
-//     {
-//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary, startupErrorCode: errorCode);
-//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby, startupErrorCode: errorCode);
-//
-//         var builder = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             Pooling = pooling,
-//         };
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString).BuildMultiHost();
-//
-//         var ex = Assert.ThrowsAsync<PostgresException>(async () => await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any))!;
-//         Assert.That(ex.SqlState, Is.EqualTo(errorCode));
-//     }
-//
-//     [Test]
-//     [Platform(Exclude = "MacOsX", Reason = "Flaky in CI on Mac")]
-//     public async Task First_host_is_down()
-//     {
-//         using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-//         var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
-//         socket.Bind(endpoint);
-//         var localEndPoint = (IPEndPoint)socket.LocalEndPoint!;
-//         // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
-//
-//         await using var postmaster = PgPostmasterMock.Start(state: Primary);
-//
-//         var connectionString = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = $"{localEndPoint.Address}:{localEndPoint.Port},{postmaster.Host}:{postmaster.Port}",
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
-//         }.ConnectionString;
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(connectionString).BuildMultiHost();
-//
-//         await using var conn = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any);
-//         Assert.That(conn.Port, Is.EqualTo(postmaster.Port));
-//     }
-//
-//     [Test]
-//     [TestCase("any")]
-//     [TestCase("primary")]
-//     [TestCase("standby")]
-//     [TestCase("prefer-primary")]
-//     [TestCase("prefer-standby")]
-//     [TestCase("read-write")]
-//     [TestCase("read-only")]
-//     public async Task TargetSessionAttributes_with_single_host(string targetSessionAttributes)
-//     {
-//         var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
-//         {
-//             TargetSessionAttributes = targetSessionAttributes
-//         }.ConnectionString;
-//
-//         if (targetSessionAttributes == "any")
-//         {
-//             await using var postmasterMock = PgPostmasterMock.Start(ConnectionString);
-//             using var pool = CreateTempPool(postmasterMock.ConnectionString, out connectionString);
-//             await using var conn = new NpgsqlConnection(connectionString);
-//             await conn.OpenAsync();
-//             _ = await postmasterMock.WaitForServerConnection();
-//         }
-//         else
-//         {
-//             Assert.That(() => new NpgsqlConnection(connectionString), Throws.Exception.TypeOf<NotSupportedException>());
-//         }
-//     }
-//
-//     [Test]
-//     public void TargetSessionAttributes_default_is_null()
-//         => Assert.That(new NpgsqlConnectionStringBuilder().TargetSessionAttributes, Is.Null);
-//
-//     [Test]
-//     [NonParallelizable] // Sets environment variable
-//     public async Task TargetSessionAttributes_uses_environment_variable()
-//     {
-//         using var envVarResetter = SetEnvironmentVariable("PGTARGETSESSIONATTRS", "prefer-standby");
-//
-//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
-//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
-//
-//         var builder = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
-//         };
-//
-//         Assert.That(builder.TargetSessionAttributes, Is.Null);
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString)
-//             .BuildMultiHost();
-//
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//         Assert.That(conn.Port, Is.EqualTo(standbyPostmaster.Port));
-//     }
-//
-//     [Test]
-//     public void TargetSessionAttributes_invalid_throws()
-//         => Assert.Throws<ArgumentException>(() =>
-//             new NpgsqlConnectionStringBuilder
-//             {
-//                 TargetSessionAttributes = nameof(TargetSessionAttributes_invalid_throws)
-//             });
-//
-//     [Test]
-//     public void HostRecheckSeconds_default_value()
-//     {
-//         var builder = new NpgsqlConnectionStringBuilder();
-//         Assert.That(builder.HostRecheckSeconds, Is.EqualTo(10));
-//         Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(10)));
-//     }
-//
-//     [Test]
-//     public void HostRecheckSeconds_zero_value()
-//     {
-//         var builder = new NpgsqlConnectionStringBuilder
-//         {
-//             HostRecheckSeconds = 0,
-//         };
-//         Assert.That(builder.HostRecheckSeconds, Is.EqualTo(0));
-//         Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(-1)));
-//     }
-//
-//     [Test]
-//     public void HostRecheckSeconds_invalid_throws()
-//         => Assert.Throws<ArgumentException>(() =>
-//             new NpgsqlConnectionStringBuilder
-//             {
-//                 HostRecheckSeconds = -1
-//             });
-//
-//     [Test]
-//     public async Task Connect_with_load_balancing()
-//     {
-//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
-//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
-//
-//         var defaultCsb = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             MaxPoolSize = 1,
-//             LoadBalanceHosts = true,
-//         };
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
-//             .BuildMultiHost();
-//
-//         NpgsqlConnector firstConnector;
-//         NpgsqlConnector secondConnector;
-//
-//         await using (var firstConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             firstConnector = firstConnection.Connector!;
-//         }
-//
-//         await using (var secondConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             secondConnector = secondConnection.Connector!;
-//         }
-//
-//         Assert.AreNotSame(firstConnector, secondConnector);
-//
-//         await using (var firstBalancedConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             Assert.AreSame(firstConnector, firstBalancedConnection.Connector);
-//         }
-//
-//         await using (var secondBalancedConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             Assert.AreSame(secondConnector, secondBalancedConnection.Connector);
-//         }
-//
-//         await using (var thirdBalancedConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             Assert.AreSame(firstConnector, thirdBalancedConnection.Connector);
-//         }
-//     }
-//
-//     [Test]
-//     public async Task Connect_without_load_balancing()
-//     {
-//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
-//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
-//
-//         var defaultCsb = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             MaxPoolSize = 1,
-//             LoadBalanceHosts = false,
-//         };
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
-//             .BuildMultiHost();
-//
-//         NpgsqlConnector firstConnector;
-//         NpgsqlConnector secondConnector;
-//
-//         await using (var firstConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             firstConnector = firstConnection.Connector!;
-//         }
-//         await using (var secondConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             Assert.AreSame(firstConnector, secondConnection.Connector);
-//         }
-//         await using (var firstConnection = await dataSource.OpenConnectionAsync())
-//         await using (var secondConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             secondConnector = secondConnection.Connector!;
-//         }
-//
-//         Assert.AreNotSame(firstConnector, secondConnector);
-//
-//         await using (var firstUnbalancedConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             Assert.AreSame(firstConnector, firstUnbalancedConnection.Connector);
-//         }
-//
-//         await using (var secondUnbalancedConnection = await dataSource.OpenConnectionAsync())
-//         {
-//             Assert.AreSame(firstConnector, secondUnbalancedConnection.Connector);
-//         }
-//     }
-//
-//     [Test]
-//     public async Task Connect_state_changing_hosts([Values] bool alwaysCheckHostState)
-//     {
-//         await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
-//         await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
-//
-//         var defaultCsb = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             MaxPoolSize = 1,
-//             HostRecheckSeconds = alwaysCheckHostState ? 0 : int.MaxValue,
-//             NoResetOnClose = true,
-//         };
-//
-//         await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
-//             .BuildMultiHost();
-//
-//         NpgsqlConnector firstConnector;
-//         NpgsqlConnector secondConnector;
-//         var firstServerTask = Task.Run(async () =>
-//         {
-//             var server = await primaryPostmaster.WaitForServerConnection();
-//             if (!alwaysCheckHostState)
-//                 return;
-//
-//             // If we always check the host, we will send the request for the state
-//             // even though we got one while opening the connection
-//             await server.SendMockState(Primary);
-//
-//             // Update the state after a 'failover'
-//             await server.SendMockState(Standby);
-//         });
-//         var secondServerTask = Task.Run(async () =>
-//         {
-//             var server = await standbyPostmaster.WaitForServerConnection();
-//             if (!alwaysCheckHostState)
-//                 return;
-//
-//             // If we always check the host, we will send the request for the state
-//             // even though we got one while opening the connection
-//             await server.SendMockState(Standby);
-//
-//             // As TargetSessionAttributes is 'prefer', it does another cycle for the 'unpreferred'
-//             await server.SendMockState(Standby);
-//             // Update the state after a 'failover'
-//             await server.SendMockState(Primary);
-//         });
-//
-//         await using (var firstConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary))
-//         await using (var secondConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary))
-//         {
-//             firstConnector = firstConnection.Connector!;
-//             secondConnector = secondConnection.Connector!;
-//         }
-//
-//         await using var thirdConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary);
-//         Assert.AreSame(alwaysCheckHostState ? secondConnector : firstConnector, thirdConnection.Connector);
-//
-//         await firstServerTask;
-//         await secondServerTask;
-//     }
-//
-//     [Test]
-//     public void Database_state_cache_basic()
-//     {
-//         using var dataSource = CreateDataSource();
-//         var timeStamp = DateTime.UtcNow;
-//
-//         dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadWrite, timeStamp, TimeSpan.Zero);
-//         Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState());
-//
-//         // Update with the same timestamp - shouldn't change anything
-//         dataSource.UpdateDatabaseState(DatabaseState.Standby, timeStamp, TimeSpan.Zero);
-//         Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState());
-//
-//         // Update with a new timestamp
-//         timeStamp = timeStamp.AddSeconds(1);
-//         dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadOnly, timeStamp, TimeSpan.Zero);
-//         Assert.AreEqual(DatabaseState.PrimaryReadOnly, dataSource.GetDatabaseState());
-//
-//         // Expired state returns as Unknown (depending on ignoreExpiration)
-//         timeStamp = timeStamp.AddSeconds(1);
-//         dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadWrite, timeStamp, TimeSpan.FromSeconds(-1));
-//         Assert.AreEqual(DatabaseState.Unknown, dataSource.GetDatabaseState(ignoreExpiration: false));
-//         Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState(ignoreExpiration: true));
-//     }
-//
-//     [Test]
-//     public async Task Offline_state_on_connection_failure()
-//     {
-//         await using var server = PgPostmasterMock.Start(ConnectionString, startupErrorCode: PostgresErrorCodes.ConnectionFailure);
-//         await using var dataSource = server.CreateDataSource();
-//         await using var conn = dataSource.CreateConnection();
-//
-//         var ex = Assert.ThrowsAsync<PostgresException>(conn.OpenAsync)!;
-//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.ConnectionFailure));
-//
-//         var state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Offline));
-//     }
-//
-//     [Test]
-//     public async Task Unknown_state_on_connection_authentication_failure()
-//     {
-//         await using var server = PgPostmasterMock.Start(ConnectionString, startupErrorCode: PostgresErrorCodes.InvalidAuthorizationSpecification);
-//         await using var dataSource = server.CreateDataSource();
-//         await using var conn = dataSource.CreateConnection();
-//
-//         var ex = Assert.ThrowsAsync<PostgresException>(conn.OpenAsync)!;
-//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.InvalidAuthorizationSpecification));
-//
-//         var state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//     }
-//
-//     [Test]
-//     public async Task Offline_state_on_query_execution_pg_critical_failure()
-//     {
-//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-//         await using var dataSource = postmaster.CreateDataSource();
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//         await using var anotherConn = await dataSource.OpenConnectionAsync();
-//         await anotherConn.CloseAsync();
-//
-//         var state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-//
-//         var server = await postmaster.WaitForServerConnection();
-//         await server.WriteErrorResponse(PostgresErrorCodes.CrashShutdown).FlushAsync();
-//
-//         var ex = Assert.ThrowsAsync<PostgresException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
-//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.CrashShutdown));
-//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-//
-//         state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Offline));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
-//     }
-//
-//     [Test, NonParallelizable]
-//     public async Task Offline_state_on_query_execution_pg_non_critical_failure()
-//     {
-//         await using var dataSource = CreateDataSource();
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//
-//         // Starting with PG14 we get the cluster's state from PG automatically
-//         var expectedState = conn.PostgreSqlVersion.Major > 13 ? DatabaseState.PrimaryReadWrite : DatabaseState.Unknown;
-//
-//         var state = dataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(expectedState));
-//         Assert.That(dataSource.Statistics.Total, Is.EqualTo(1));
-//
-//         var ex = Assert.ThrowsAsync<PostgresException>(() => conn.ExecuteNonQueryAsync("SELECT abc"))!;
-//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.UndefinedColumn));
-//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
-//
-//         state = dataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(expectedState));
-//         Assert.That(dataSource.Statistics.Total, Is.EqualTo(1));
-//     }
-//
-//     [Test]
-//     public async Task Offline_state_on_query_execution_IOException()
-//     {
-//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-//         await using var dataSource = postmaster.CreateDataSource();
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//         await using var anotherConn = await dataSource.OpenConnectionAsync();
-//         await anotherConn.CloseAsync();
-//
-//         var state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-//
-//         var server = await postmaster.WaitForServerConnection();
-//         server.Close();
-//
-//         var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
-//         Assert.That(ex.InnerException, Is.InstanceOf<IOException>());
-//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-//
-//         state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Offline));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
-//     }
-//
-//     [Test]
-//     public async Task Offline_state_on_query_execution_TimeoutException()
-//     {
-//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-//         var dataSourceBuilder = postmaster.GetDataSourceBuilder();
-//         dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
-//         dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = 1;
-//         await using var dataSource = dataSourceBuilder.Build();
-//
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//         await using var anotherConn = await dataSource.OpenConnectionAsync();
-//         await anotherConn.CloseAsync();
-//
-//         var state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-//
-//         var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
-//         Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
-//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-//
-//         state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Offline));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
-//     }
-//
-//     [Test]
-//     public async Task Unknown_state_on_query_execution_TimeoutException_with_disabled_cancellation()
-//     {
-//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-//         var dataSourceBuilder = postmaster.GetDataSourceBuilder();
-//         dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
-//         dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = -1;
-//         await using var dataSource = dataSourceBuilder.Build();
-//
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//         await using var anotherConn = await dataSource.OpenConnectionAsync();
-//         await anotherConn.CloseAsync();
-//
-//         var state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-//
-//         var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
-//         Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
-//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-//
-//         state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-//     }
-//
-//     [Test]
-//     public async Task Unknown_state_on_query_execution_cancellation_with_disabled_cancellation_timeout()
-//     {
-//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-//         var dataSourceBuilder = postmaster.GetDataSourceBuilder();
-//         dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 30;
-//         dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = -1;
-//         await using var dataSource = dataSourceBuilder.Build();
-//
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//         await using var anotherConn = await dataSource.OpenConnectionAsync();
-//         await anotherConn.CloseAsync();
-//
-//         var state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
-//
-//         using var cts = new CancellationTokenSource();
-//
-//         var query = conn.ExecuteNonQueryAsync("SELECT 1", cancellationToken: cts.Token);
-//         cts.Cancel();
-//         var ex = Assert.ThrowsAsync<OperationCanceledException>(async () => await query)!;
-//         Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
-//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
-//
-//         state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-//     }
-//
-//     [Test]
-//     public async Task Unknown_state_on_query_execution_TimeoutException_with_cancellation_failure()
-//     {
-//         await using var postmaster = PgPostmasterMock.Start(ConnectionString);
-//         var dataSourceBuilder = postmaster.GetDataSourceBuilder();
-//         dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
-//         dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = 0;
-//         await using var dataSource = dataSourceBuilder.Build();
-//
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//
-//         var state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-//
-//         var server = await postmaster.WaitForServerConnection();
-//
-//         var query = conn.ExecuteNonQueryAsync("SELECT 1");
-//
-//         await postmaster.WaitForCancellationRequest();
-//         await server.WriteCancellationResponse().WriteReadyForQuery().FlushAsync();
-//
-//         var ex = Assert.ThrowsAsync<NpgsqlException>(async () => await query)!;
-//         Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
-//         Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
-//
-//         state = conn.NpgsqlDataSource.GetDatabaseState();
-//         Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-//     }
-//
-//     [Test]
-//     public async Task Clear_pool_one_host_only_on_admin_shutdown()
-//     {
-//         await using var primaryPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
-//         await using var standbyPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
-//         var dataSourceBuilder = new NpgsqlDataSourceBuilder
-//         {
-//             ConnectionStringBuilder =
-//             {
-//                 Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//                 MaxPoolSize = 2
-//             }
-//         };
-//         await using var multiHostDataSource = dataSourceBuilder.BuildMultiHost();
-//         await using var preferPrimaryDataSource = multiHostDataSource.WithTargetSession(TargetSessionAttributes.PreferPrimary);
-//
-//         await using var primaryConn = await preferPrimaryDataSource.OpenConnectionAsync();
-//         await using var anotherPrimaryConn = await preferPrimaryDataSource.OpenConnectionAsync();
-//         await using var standbyConn = await preferPrimaryDataSource.OpenConnectionAsync();
-//         var primaryDataSource = primaryConn.Connector!.DataSource;
-//         var standbyDataSource = standbyConn.Connector!.DataSource;
-//         await anotherPrimaryConn.CloseAsync();
-//         await standbyConn.CloseAsync();
-//
-//         Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.PrimaryReadWrite));
-//         Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
-//         Assert.That(primaryConn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(3));
-//
-//         var server = await primaryPostmaster.WaitForServerConnection();
-//         await server.WriteErrorResponse(PostgresErrorCodes.AdminShutdown).FlushAsync();
-//
-//         var ex = Assert.ThrowsAsync<PostgresException>(() => primaryConn.ExecuteNonQueryAsync("SELECT 1"))!;
-//         Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.AdminShutdown));
-//         Assert.That(primaryConn.State, Is.EqualTo(ConnectionState.Closed));
-//
-//         Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Offline));
-//         Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
-//         Assert.That(primaryConn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
-//
-//         multiHostDataSource.ClearDatabaseStates();
-//         Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
-//     }
-//
-//     [Test]
-//     [TestCase("any", true)]
-//     [TestCase("primary", true)]
-//     [TestCase("standby", false)]
-//     [TestCase("prefer-primary", true)]
-//     [TestCase("prefer-standby", false)]
-//     [TestCase("read-write", true)]
-//     [TestCase("read-only", false)]
-//     public async Task Transaction_enlist_reuses_connection(string targetSessionAttributes, bool primary)
-//     {
-//         await using var primaryPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
-//         await using var standbyPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
-//         var csb = new NpgsqlConnectionStringBuilder
-//         {
-//             Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
-//             TargetSessionAttributes = targetSessionAttributes,
-//             ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             MaxPoolSize = 10,
-//         };
-//
-//         using var _ = CreateTempPool(csb, out var connString);
-//
-//         using var scope = new TransactionScope(TransactionScopeOption.Required,
-//             new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }, TransactionScopeAsyncFlowOption.Enabled);
-//
-//         var query1Task = Query(connString);
-//
-//         var server = primary
-//             ? await primaryPostmaster.WaitForServerConnection()
-//             : await standbyPostmaster.WaitForServerConnection();
-//
-//         await server
-//             .WriteCommandComplete()
-//             .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
-//             .WriteParseComplete()
-//             .WriteBindComplete()
-//             .WriteNoData()
-//             .WriteCommandComplete()
-//             .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
-//             .FlushAsync();
-//         await query1Task;
-//
-//         var query2Task = Query(connString);
-//         await server
-//             .WriteParseComplete()
-//             .WriteBindComplete()
-//             .WriteNoData()
-//             .WriteCommandComplete()
-//             .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
-//             .FlushAsync();
-//         await query2Task;
-//
-//         await server
-//             .WriteCommandComplete()
-//             .WriteReadyForQuery()
-//             .FlushAsync();
-//         scope.Complete();
-//
-//         async Task Query(string connectionString)
-//         {
-//             await using var conn = new NpgsqlConnection(connectionString);
-//             await conn.OpenAsync();
-//
-//             await using var cmd = conn.CreateCommand();
-//             cmd.CommandText = "SELECT 1";
-//             await cmd.ExecuteNonQueryAsync();
-//         }
-//     }
-//
-//     [Test]
-//     public async Task Primary_host_failover_can_connect()
-//     {
-//         await using var firstPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
-//         await using var secondPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
-//         var dataSourceBuilder = new NpgsqlDataSourceBuilder
-//         {
-//             ConnectionStringBuilder =
-//             {
-//                 Host = MultipleHosts(firstPostmaster, secondPostmaster),
-//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//                 HostRecheckSeconds = 5
-//             }
-//         };
-//         await using var multiHostDataSource = dataSourceBuilder.BuildMultiHost();
-//         var (firstDataSource, secondDataSource) = (multiHostDataSource.Pools[0], multiHostDataSource.Pools[1]);
-//         await using var primaryDataSource = multiHostDataSource.WithTargetSession(TargetSessionAttributes.Primary);
-//
-//         await using var conn = await primaryDataSource.OpenConnectionAsync();
-//         Assert.That(conn.Port, Is.EqualTo(firstPostmaster.Port));
-//         var firstServer = await firstPostmaster.WaitForServerConnection();
-//         await firstServer
-//             .WriteErrorResponse(PostgresErrorCodes.AdminShutdown)
-//             .FlushAsync();
-//
-//         var failoverEx = Assert.ThrowsAsync<PostgresException>(async () => await conn.ExecuteNonQueryAsync("SELECT 1"))!;
-//         Assert.That(failoverEx.SqlState, Is.EqualTo(PostgresErrorCodes.AdminShutdown));
-//
-//         var noHostFoundEx = Assert.ThrowsAsync<NpgsqlException>(async () => await conn.OpenAsync())!;
-//         Assert.That(noHostFoundEx.Message, Is.EqualTo("No suitable host was found."));
-//
-//         Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Offline));
-//         Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
-//
-//         firstPostmaster.State = Standby;
-//         secondPostmaster.State = Primary;
-//         var secondServer = await secondPostmaster.WaitForServerConnection();
-//         await secondServer.SendMockState(Primary);
-//
-//         await Task.Delay(TimeSpan.FromSeconds(10));
-//         Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
-//         Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
-//
-//         await conn.OpenAsync();
-//         Assert.That(conn.Port, Is.EqualTo(secondPostmaster.Port));
-//         Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
-//         Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.PrimaryReadWrite));
-//     }
-//
-//     [Test, NonParallelizable]
-//     public void IntegrationTest([Values] bool loadBalancing, [Values] bool alwaysCheckHostState)
-//     {
-//         PoolManager.Reset();
-//
-//         var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
-//         {
-//             ConnectionStringBuilder =
-//             {
-//                 Host = "localhost,127.0.0.1",
-//                 Pooling = true,
-//                 MaxPoolSize = 2,
-//                 LoadBalanceHosts = loadBalancing,
-//                 HostRecheckSeconds = alwaysCheckHostState ? 0 : 10,
-//             }
-//         };
-//         using var dataSource = dataSourceBuilder.BuildMultiHost();
-//
-//         var queriesDone = 0;
-//
-//         var clientsTask = Task.WhenAll(
-//             Client(dataSource, TargetSessionAttributes.Any),
-//             Client(dataSource, TargetSessionAttributes.Primary),
-//             Client(dataSource, TargetSessionAttributes.PreferPrimary),
-//             Client(dataSource, TargetSessionAttributes.PreferStandby),
-//             Client(dataSource, TargetSessionAttributes.ReadWrite));
-//
-//         var onlyStandbyClient = Client(dataSource, TargetSessionAttributes.Standby);
-//         var readOnlyClient = Client(dataSource, TargetSessionAttributes.ReadOnly);
-//
-//         Assert.DoesNotThrowAsync(() => clientsTask);
-//         Assert.ThrowsAsync<NpgsqlException>(() => onlyStandbyClient);
-//         Assert.ThrowsAsync<NpgsqlException>(() => readOnlyClient);
-//         Assert.AreEqual(125, queriesDone);
-//
-//         Task Client(NpgsqlMultiHostDataSource multiHostDataSource, TargetSessionAttributes targetSessionAttributes)
-//         {
-//             var dataSource = multiHostDataSource.WithTargetSession(targetSessionAttributes);
-//             var tasks = new List<Task>(5);
-//
-//             for (var i = 0; i < 5; i++)
-//             {
-//                 tasks.Add(Task.Run(() => Query(dataSource)));
-//             }
-//
-//             return Task.WhenAll(tasks);
-//         }
-//
-//         async Task Query(NpgsqlDataSource dataSource)
-//         {
-//             await using var conn = dataSource.CreateConnection();
-//             for (var i = 0; i < 5; i++)
-//             {
-//                 await conn.OpenAsync();
-//                 await conn.ExecuteNonQueryAsync("SELECT 1");
-//                 await conn.CloseAsync();
-//                 Interlocked.Increment(ref queriesDone);
-//             }
-//         }
-//     }
-//
-//     [Test]
-//     [IssueLink("https://github.com/npgsql/npgsql/issues/5055")]
-//     [NonParallelizable] // Disables sql rewriting
-//     public async Task Multiple_hosts_with_disabled_sql_rewriting()
-//     {
-//         using var _ = DisableSqlRewriting();
-//
-//         var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
-//         {
-//             ConnectionStringBuilder =
-//             {
-//                 Host = "localhost,127.0.0.1",
-//                 Pooling = true,
-//                 HostRecheckSeconds = 0
-//             }
-//         };
-//         await using var dataSource = dataSourceBuilder.BuildMultiHost();
-//         await using var conn = await dataSource.OpenConnectionAsync();
-//     }
-//
-//     [Test]
-//     public async Task DataSource_with_wrappers()
-//     {
-//         await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
-//         await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
-//
-//         var builder = new NpgsqlDataSourceBuilder
-//         {
-//             ConnectionStringBuilder =
-//             {
-//                 Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
-//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             }
-//         };
-//
-//         await using var dataSource = builder.BuildMultiHost();
-//         await using var primaryDataSource = dataSource.WithTargetSession(TargetSessionAttributes.Primary);
-//         await using var standbyDataSource = dataSource.WithTargetSession(TargetSessionAttributes.Standby);
-//
-//         await using var primaryConnection = await primaryDataSource.OpenConnectionAsync();
-//         Assert.That(primaryConnection.Port, Is.EqualTo(primaryPostmasterMock.Port));
-//
-//         await using var standbyConnection = await standbyDataSource.OpenConnectionAsync();
-//         Assert.That(standbyConnection.Port, Is.EqualTo(standbyPostmasterMock.Port));
-//     }
-//
-//     [Test]
-//     public async Task DataSource_without_wrappers()
-//     {
-//         await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
-//         await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
-//
-//         var builder = new NpgsqlDataSourceBuilder
-//         {
-//             ConnectionStringBuilder =
-//             {
-//                 Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
-//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             }
-//         };
-//
-//         await using var dataSource = builder.BuildMultiHost();
-//
-//         await using var primaryConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Primary);
-//         Assert.That(primaryConnection.Port, Is.EqualTo(primaryPostmasterMock.Port));
-//
-//         await using var standbyConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Standby);
-//         Assert.That(standbyConnection.Port, Is.EqualTo(standbyPostmasterMock.Port));
-//     }
-//
-//     [Test]
-//     public void DataSource_with_TargetSessionAttributes_is_not_supported()
-//     {
-//         var builder = new NpgsqlDataSourceBuilder("Host=foo,bar;Target Session Attributes=primary");
-//
-//         Assert.That(() => builder.BuildMultiHost(), Throws.Exception.TypeOf<InvalidOperationException>()
-//             .With.Message.EqualTo(NpgsqlStrings.CannotSpecifyTargetSessionAttributes));
-//     }
-//
-//     [Test]
-//     public async Task BuildMultiHost_with_single_host_is_supported()
-//     {
-//         var builder = new NpgsqlDataSourceBuilder(ConnectionString);
-//         await using var dataSource = builder.BuildMultiHost();
-//         await using var connection = await dataSource.OpenConnectionAsync();
-//         Assert.That(await connection.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
-//     }
-//
-//     [Test]
-//     public async Task Build_with_multiple_hosts_is_supported()
-//     {
-//         await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
-//         await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
-//
-//         var builder = new NpgsqlDataSourceBuilder
-//         {
-//             ConnectionStringBuilder =
-//             {
-//                 Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
-//                 ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
-//             }
-//         };
-//
-//         await using var dataSource = builder.Build();
-//         await using var connection = await dataSource.OpenConnectionAsync();
-//     }
-//
-//     [Test, IssueLink("https://github.com/npgsql/npgsql/issues/4181")]
-//     [Explicit("Fails until #4181 is fixed.")]
-//     public async Task LoadBalancing_is_fair_if_first_host_is_down([Values]TargetSessionAttributes targetSessionAttributes)
-//     {
-//         await using var pDown = PgPostmasterMock.Start(state: Primary, startupErrorCode: PostgresErrorCodes.CannotConnectNow);
-//         await using var pRw1 = PgPostmasterMock.Start(state: Primary);
-//         await using var pR1 = PgPostmasterMock.Start(state: PrimaryReadOnly);
-//         await using var s1 = PgPostmasterMock.Start(state: Standby);
-//         await using var pRw2 = PgPostmasterMock.Start(state: Primary);
-//         await using var pR2 = PgPostmasterMock.Start(state: PrimaryReadOnly);
-//         await using var s2 = PgPostmasterMock.Start(state: Standby);
-//
-//         var hostList = $"{pDown.Host}:{pDown.Port}," +
-//                        $"{pRw1.Host}:{pRw1.Port}," +
-//                        $"{pR1.Host}:{pR1.Port}," +
-//                        $"{s1.Host}:{s1.Port}," +
-//                        $"{pRw2.Host}:{pRw2.Port}," +
-//                        $"{pR2.Host}:{pR2.Port}," +
-//                        $"{s2.Host}:{s2.Port}";
-//
-//         await using var dataSource = CreateDataSource(builder =>
-//         {
-//             builder.Host = hostList;
-//             builder.ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading;
-//             builder.LoadBalanceHosts = true;
-//             builder.TargetSessionAttributesParsed = targetSessionAttributes;
-//
-//         });
-//         var connections = Enumerable.Repeat(0, 12).Select(_ => dataSource.OpenConnection()).ToArray();
-//         await using var __ = new DisposableWrapper(connections);
-//
-//         switch (targetSessionAttributes)
-//         {
-//         case TargetSessionAttributes.Any:
-//             Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[1].Port, Is.EqualTo(pR1.Port));
-//             Assert.That(connections[2].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[3].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[4].Port, Is.EqualTo(pR2.Port));
-//             Assert.That(connections[5].Port, Is.EqualTo(s2.Port));
-//             Assert.That(connections[6].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[7].Port, Is.EqualTo(pR1.Port));
-//             Assert.That(connections[8].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[9].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[10].Port, Is.EqualTo(pR2.Port));
-//             Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
-//             break;
-//         case TargetSessionAttributes.ReadWrite:
-//             Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[1].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[2].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[3].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[4].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[5].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[6].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[7].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[8].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[9].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[10].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[11].Port, Is.EqualTo(pRw2.Port));
-//             break;
-//         case TargetSessionAttributes.ReadOnly:
-//             Assert.That(connections[0].Port, Is.EqualTo(pR1.Port));
-//             Assert.That(connections[1].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[2].Port, Is.EqualTo(pR2.Port));
-//             Assert.That(connections[3].Port, Is.EqualTo(s2.Port));
-//             Assert.That(connections[4].Port, Is.EqualTo(pR1.Port));
-//             Assert.That(connections[5].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[6].Port, Is.EqualTo(pR2.Port));
-//             Assert.That(connections[7].Port, Is.EqualTo(s2.Port));
-//             Assert.That(connections[8].Port, Is.EqualTo(pR1.Port));
-//             Assert.That(connections[9].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[10].Port, Is.EqualTo(pR2.Port));
-//             Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
-//             break;
-//         case TargetSessionAttributes.Primary:
-//         case TargetSessionAttributes.PreferPrimary:
-//             Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[1].Port, Is.EqualTo(pR1.Port));
-//             Assert.That(connections[2].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[3].Port, Is.EqualTo(pR2.Port));
-//             Assert.That(connections[4].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[5].Port, Is.EqualTo(pR1.Port));
-//             Assert.That(connections[6].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[7].Port, Is.EqualTo(pR2.Port));
-//             Assert.That(connections[8].Port, Is.EqualTo(pRw1.Port));
-//             Assert.That(connections[9].Port, Is.EqualTo(pR1.Port));
-//             Assert.That(connections[10].Port, Is.EqualTo(pRw2.Port));
-//             Assert.That(connections[11].Port, Is.EqualTo(pR2.Port));
-//             break;
-//         case TargetSessionAttributes.Standby:
-//         case TargetSessionAttributes.PreferStandby:
-//             Assert.That(connections[0].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[1].Port, Is.EqualTo(s2.Port));
-//             Assert.That(connections[2].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[3].Port, Is.EqualTo(s2.Port));
-//             Assert.That(connections[4].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[5].Port, Is.EqualTo(s2.Port));
-//             Assert.That(connections[6].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[7].Port, Is.EqualTo(s2.Port));
-//             Assert.That(connections[8].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[9].Port, Is.EqualTo(s2.Port));
-//             Assert.That(connections[10].Port, Is.EqualTo(s1.Port));
-//             Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
-//             break;
-//         }
-//     }
-//
-//     static string MultipleHosts(params PgPostmasterMock[] postmasters)
-//         => string.Join(",", postmasters.Select(p => $"{p.Host}:{p.Port}"));
-//
-//     class DisposableWrapper : IAsyncDisposable
-//     {
-//         readonly IEnumerable<IAsyncDisposable> _disposables;
-//
-//         public DisposableWrapper(IEnumerable<IAsyncDisposable> disposables) => _disposables = disposables;
-//
-//         public async ValueTask DisposeAsync()
-//         {
-//             foreach (var disposable in _disposables)
-//                 await disposable.DisposeAsync();
-//         }
-//     }
-// }
+﻿using YBNpgsql.Internal;
+using YBNpgsql.Tests.Support;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using YBNpgsql.Properties;
+using static YBNpgsql.Tests.Support.MockState;
+using static YBNpgsql.Tests.TestUtil;
+using IsolationLevel = System.Transactions.IsolationLevel;
+using TransactionStatus = YBNpgsql.Internal.TransactionStatus;
+
+namespace YBNpgsql.Tests;
+
+public class MultipleHostsTests : TestBase
+{
+    static readonly object[] MyCases =
+    {
+        new object[] { TargetSessionAttributes.Standby,        new[] { Primary,         Standby         }, 1 },
+        new object[] { TargetSessionAttributes.Standby,        new[] { PrimaryReadOnly, Standby         }, 1 },
+        new object[] { TargetSessionAttributes.PreferStandby,  new[] { Primary,         Standby         }, 1 },
+        new object[] { TargetSessionAttributes.PreferStandby,  new[] { PrimaryReadOnly, Standby         }, 1 },
+        new object[] { TargetSessionAttributes.PreferStandby,  new[] { Primary,         Primary         }, 0 },
+        new object[] { TargetSessionAttributes.Primary,        new[] { Standby,         Primary         }, 1 },
+        new object[] { TargetSessionAttributes.Primary,        new[] { Standby,         PrimaryReadOnly }, 1 },
+        new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         Primary         }, 1 },
+        new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         PrimaryReadOnly }, 1 },
+        new object[] { TargetSessionAttributes.PreferPrimary,  new[] { Standby,         Standby         }, 0 },
+        new object[] { TargetSessionAttributes.Any,            new[] { Standby,         Primary         }, 0 },
+        new object[] { TargetSessionAttributes.Any,            new[] { Primary,         Standby         }, 0 },
+        new object[] { TargetSessionAttributes.Any,            new[] { PrimaryReadOnly, Standby         }, 0 },
+        new object[] { TargetSessionAttributes.ReadWrite,      new[] { Standby,         Primary         }, 1 },
+        new object[] { TargetSessionAttributes.ReadWrite,      new[] { PrimaryReadOnly, Primary         }, 1 },
+        new object[] { TargetSessionAttributes.ReadOnly,       new[] { Primary,         Standby         }, 1 },
+        new object[] { TargetSessionAttributes.ReadOnly,       new[] { PrimaryReadOnly, Standby         }, 0 }
+    };
+
+    [Test]
+    [TestCaseSource(nameof(MyCases))]
+    public async Task Connect_to_correct_host_pooled(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
+    {
+        var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+        await using var __ = new DisposableWrapper(postmasters);
+
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(postmasters),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            Pooling = true
+        };
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
+            .BuildMultiHost();
+        await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
+
+        Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
+
+        for (var i = 0; i <= expectedServer; i++)
+            _ = await postmasters[i].WaitForServerConnection();
+    }
+
+    [Test]
+    [TestCaseSource(nameof(MyCases))]
+    public async Task Connect_to_correct_host_unpooled(TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
+    {
+        var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+        await using var __ = new DisposableWrapper(postmasters);
+
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(postmasters),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            Pooling = false
+        };
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
+            .BuildMultiHost();
+        await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
+
+        Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
+
+        for (var i = 0; i <= expectedServer; i++)
+            _ = await postmasters[i].WaitForServerConnection();
+    }
+
+    [Test]
+    [TestCaseSource(nameof(MyCases))]
+    public async Task Connect_to_correct_host_with_available_idle(
+        TargetSessionAttributes targetSessionAttributes, MockState[] servers, int expectedServer)
+    {
+        var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+        await using var __ = new DisposableWrapper(postmasters);
+
+        // First, open and close a connection with the TargetSessionAttributes matching the first server.
+        // This ensures wew have an idle connection in the pool.
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(postmasters),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+        };
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
+            .BuildMultiHost();
+        var idleConnTargetSessionAttributes = servers[0] switch
+        {
+            Primary => TargetSessionAttributes.ReadWrite,
+            PrimaryReadOnly => TargetSessionAttributes.ReadOnly,
+            Standby => TargetSessionAttributes.Standby,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+        await using (_ = await dataSource.OpenConnectionAsync(idleConnTargetSessionAttributes))
+        {
+            // Do nothing, close to have an idle connection in the pool.
+        }
+
+        // Now connect with the test TargetSessionAttributes
+
+        await using var conn = await dataSource.OpenConnectionAsync(targetSessionAttributes);
+
+        Assert.That(conn.Port, Is.EqualTo(postmasters[expectedServer].Port));
+
+        for (var i = 0; i <= expectedServer; i++)
+            _ = await postmasters[i].WaitForServerConnection();
+    }
+
+    [Test]
+    [TestCase(TargetSessionAttributes.Standby,   new[] { Primary,         Primary })]
+    [TestCase(TargetSessionAttributes.Primary,   new[] { Standby,         Standby })]
+    [TestCase(TargetSessionAttributes.ReadWrite, new[] { PrimaryReadOnly, Standby })]
+    [TestCase(TargetSessionAttributes.ReadOnly,  new[] { Primary,         Primary })]
+    public async Task Valid_host_not_found(TargetSessionAttributes targetSessionAttributes, MockState[] servers)
+    {
+        var postmasters = servers.Select(s => PgPostmasterMock.Start(state: s)).ToArray();
+        await using var __ = new DisposableWrapper(postmasters);
+
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(postmasters),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+        };
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString)
+            .BuildMultiHost();
+
+        var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await dataSource.OpenConnectionAsync(targetSessionAttributes))!;
+        Assert.That(exception.Message, Is.EqualTo("No suitable host was found."));
+        Assert.That(exception.InnerException, Is.Null);
+
+        for (var i = 0; i < servers.Length; i++)
+            _ = await postmasters[i].WaitForServerConnection();
+    }
+
+    [Test, Platform(Exclude = "MacOsX", Reason = "#3786")]
+    public void All_hosts_are_down()
+    {
+        // Different exception raised in .NET Core 3.1, skip (NUnit doesn't seem to support detecting .NET Core versions)
+        if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Core 3.1"))
+            return;
+
+        var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+
+        using var socket1 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        socket1.Bind(endpoint);
+        var localEndPoint1 = (IPEndPoint)socket1.LocalEndPoint!;
+
+        using var socket2 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        socket2.Bind(endpoint);
+        var localEndPoint2 = (IPEndPoint)socket2.LocalEndPoint!;
+
+        // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
+
+        var connectionString = new NpgsqlConnectionStringBuilder
+        {
+            Host = $"{localEndPoint1.Address}:{localEndPoint1.Port},{localEndPoint2.Address}:{localEndPoint2.Port}"
+        }.ConnectionString;
+        using var dataSource = new NpgsqlDataSourceBuilder(connectionString).BuildMultiHost();
+
+        var exception = Assert.ThrowsAsync<NpgsqlException>(async () => await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any))!;
+        var aggregateException = (AggregateException)exception.InnerException!;
+        Assert.That(aggregateException.InnerExceptions, Has.Count.EqualTo(2));
+
+        for (var i = 0; i < aggregateException.InnerExceptions.Count; i++)
+        {
+            Assert.That(aggregateException.InnerExceptions[i], Is.TypeOf<NpgsqlException>()
+                .With.InnerException.TypeOf<SocketException>()
+                .With.InnerException.Property(nameof(SocketException.SocketErrorCode)).EqualTo(SocketError.ConnectionRefused));
+        }
+    }
+
+    [Test]
+    public async Task All_hosts_are_unavailable(
+        [Values] bool pooling,
+        [Values(PostgresErrorCodes.InvalidCatalogName, PostgresErrorCodes.CannotConnectNow)] string errorCode)
+    {
+        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary, startupErrorCode: errorCode);
+        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby, startupErrorCode: errorCode);
+
+        var builder = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            Pooling = pooling,
+        };
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString).BuildMultiHost();
+
+        var ex = Assert.ThrowsAsync<PostgresException>(async () => await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any))!;
+        Assert.That(ex.SqlState, Is.EqualTo(errorCode));
+    }
+
+    [Test]
+    [Platform(Exclude = "MacOsX", Reason = "Flaky in CI on Mac")]
+    public async Task First_host_is_down()
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+        socket.Bind(endpoint);
+        var localEndPoint = (IPEndPoint)socket.LocalEndPoint!;
+        // Note that we Bind (to reserve the port), but do not Listen - connection attempts will fail.
+
+        await using var postmaster = PgPostmasterMock.Start(state: Primary);
+
+        var connectionString = new NpgsqlConnectionStringBuilder
+        {
+            Host = $"{localEndPoint.Address}:{localEndPoint.Port},{postmaster.Host}:{postmaster.Port}",
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
+        }.ConnectionString;
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(connectionString).BuildMultiHost();
+
+        await using var conn = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Any);
+        Assert.That(conn.Port, Is.EqualTo(postmaster.Port));
+    }
+
+    [Test]
+    [TestCase("any")]
+    [TestCase("primary")]
+    [TestCase("standby")]
+    [TestCase("prefer-primary")]
+    [TestCase("prefer-standby")]
+    [TestCase("read-write")]
+    [TestCase("read-only")]
+    public async Task TargetSessionAttributes_with_single_host(string targetSessionAttributes)
+    {
+        var connectionString = new NpgsqlConnectionStringBuilder(ConnectionString)
+        {
+            TargetSessionAttributes = targetSessionAttributes
+        }.ConnectionString;
+
+        if (targetSessionAttributes == "any")
+        {
+            await using var postmasterMock = PgPostmasterMock.Start(ConnectionString);
+            using var pool = CreateTempPool(postmasterMock.ConnectionString, out connectionString);
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+            _ = await postmasterMock.WaitForServerConnection();
+        }
+        else
+        {
+            Assert.That(() => new NpgsqlConnection(connectionString), Throws.Exception.TypeOf<NotSupportedException>());
+        }
+    }
+
+    [Test]
+    public void TargetSessionAttributes_default_is_null()
+        => Assert.That(new NpgsqlConnectionStringBuilder().TargetSessionAttributes, Is.Null);
+
+    [Test]
+    [NonParallelizable] // Sets environment variable
+    public async Task TargetSessionAttributes_uses_environment_variable()
+    {
+        using var envVarResetter = SetEnvironmentVariable("PGTARGETSESSIONATTRS", "prefer-standby");
+
+        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+
+        var builder = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading
+        };
+
+        Assert.That(builder.TargetSessionAttributes, Is.Null);
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(builder.ConnectionString)
+            .BuildMultiHost();
+
+        await using var conn = await dataSource.OpenConnectionAsync();
+        Assert.That(conn.Port, Is.EqualTo(standbyPostmaster.Port));
+    }
+
+    [Test]
+    public void TargetSessionAttributes_invalid_throws()
+        => Assert.Throws<ArgumentException>(() =>
+            new NpgsqlConnectionStringBuilder
+            {
+                TargetSessionAttributes = nameof(TargetSessionAttributes_invalid_throws)
+            });
+
+    [Test]
+    public void HostRecheckSeconds_default_value()
+    {
+        var builder = new NpgsqlConnectionStringBuilder();
+        Assert.That(builder.HostRecheckSeconds, Is.EqualTo(10));
+        Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(10)));
+    }
+
+    [Test]
+    public void HostRecheckSeconds_zero_value()
+    {
+        var builder = new NpgsqlConnectionStringBuilder
+        {
+            HostRecheckSeconds = 0,
+        };
+        Assert.That(builder.HostRecheckSeconds, Is.EqualTo(0));
+        Assert.That(builder.HostRecheckSecondsTranslated, Is.EqualTo(TimeSpan.FromSeconds(-1)));
+    }
+
+    [Test]
+    public void HostRecheckSeconds_invalid_throws()
+        => Assert.Throws<ArgumentException>(() =>
+            new NpgsqlConnectionStringBuilder
+            {
+                HostRecheckSeconds = -1
+            });
+
+    [Test]
+    public async Task Connect_with_load_balancing()
+    {
+        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+
+        var defaultCsb = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            MaxPoolSize = 1,
+            LoadBalanceHosts = LoadBalanceHosts.True,
+        };
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
+            .BuildMultiHost();
+
+        NpgsqlConnector firstConnector;
+        NpgsqlConnector secondConnector;
+
+        await using (var firstConnection = await dataSource.OpenConnectionAsync())
+        {
+            firstConnector = firstConnection.Connector!;
+        }
+
+        await using (var secondConnection = await dataSource.OpenConnectionAsync())
+        {
+            secondConnector = secondConnection.Connector!;
+        }
+
+        Assert.AreNotSame(firstConnector, secondConnector);
+
+        await using (var firstBalancedConnection = await dataSource.OpenConnectionAsync())
+        {
+            Assert.AreSame(firstConnector, firstBalancedConnection.Connector);
+        }
+
+        await using (var secondBalancedConnection = await dataSource.OpenConnectionAsync())
+        {
+            Assert.AreSame(secondConnector, secondBalancedConnection.Connector);
+        }
+
+        await using (var thirdBalancedConnection = await dataSource.OpenConnectionAsync())
+        {
+            Assert.AreSame(firstConnector, thirdBalancedConnection.Connector);
+        }
+    }
+
+    [Test]
+    public async Task Connect_without_load_balancing()
+    {
+        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+
+        var defaultCsb = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            MaxPoolSize = 1,
+            LoadBalanceHosts = LoadBalanceHosts.False,
+        };
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
+            .BuildMultiHost();
+
+        NpgsqlConnector firstConnector;
+        NpgsqlConnector secondConnector;
+
+        await using (var firstConnection = await dataSource.OpenConnectionAsync())
+        {
+            firstConnector = firstConnection.Connector!;
+        }
+        await using (var secondConnection = await dataSource.OpenConnectionAsync())
+        {
+            Assert.AreSame(firstConnector, secondConnection.Connector);
+        }
+        await using (var firstConnection = await dataSource.OpenConnectionAsync())
+        await using (var secondConnection = await dataSource.OpenConnectionAsync())
+        {
+            secondConnector = secondConnection.Connector!;
+        }
+
+        Assert.AreNotSame(firstConnector, secondConnector);
+
+        await using (var firstUnbalancedConnection = await dataSource.OpenConnectionAsync())
+        {
+            Assert.AreSame(firstConnector, firstUnbalancedConnection.Connector);
+        }
+
+        await using (var secondUnbalancedConnection = await dataSource.OpenConnectionAsync())
+        {
+            Assert.AreSame(firstConnector, secondUnbalancedConnection.Connector);
+        }
+    }
+
+    [Test]
+    public async Task Connect_state_changing_hosts([Values] bool alwaysCheckHostState)
+    {
+        await using var primaryPostmaster = PgPostmasterMock.Start(state: Primary);
+        await using var standbyPostmaster = PgPostmasterMock.Start(state: Standby);
+
+        var defaultCsb = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            MaxPoolSize = 1,
+            HostRecheckSeconds = alwaysCheckHostState ? 0 : int.MaxValue,
+            NoResetOnClose = true,
+        };
+
+        await using var dataSource = new NpgsqlDataSourceBuilder(defaultCsb.ConnectionString)
+            .BuildMultiHost();
+
+        NpgsqlConnector firstConnector;
+        NpgsqlConnector secondConnector;
+        var firstServerTask = Task.Run(async () =>
+        {
+            var server = await primaryPostmaster.WaitForServerConnection();
+            if (!alwaysCheckHostState)
+                return;
+
+            // If we always check the host, we will send the request for the state
+            // even though we got one while opening the connection
+            await server.SendMockState(Primary);
+
+            // Update the state after a 'failover'
+            await server.SendMockState(Standby);
+        });
+        var secondServerTask = Task.Run(async () =>
+        {
+            var server = await standbyPostmaster.WaitForServerConnection();
+            if (!alwaysCheckHostState)
+                return;
+
+            // If we always check the host, we will send the request for the state
+            // even though we got one while opening the connection
+            await server.SendMockState(Standby);
+
+            // As TargetSessionAttributes is 'prefer', it does another cycle for the 'unpreferred'
+            await server.SendMockState(Standby);
+            // Update the state after a 'failover'
+            await server.SendMockState(Primary);
+        });
+
+        await using (var firstConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary))
+        await using (var secondConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary))
+        {
+            firstConnector = firstConnection.Connector!;
+            secondConnector = secondConnection.Connector!;
+        }
+
+        await using var thirdConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.PreferPrimary);
+        Assert.AreSame(alwaysCheckHostState ? secondConnector : firstConnector, thirdConnection.Connector);
+
+        await firstServerTask;
+        await secondServerTask;
+    }
+
+    [Test]
+    public void Database_state_cache_basic()
+    {
+        using var dataSource = CreateDataSource();
+        var timeStamp = DateTime.UtcNow;
+
+        dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadWrite, timeStamp, TimeSpan.Zero);
+        Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState());
+
+        // Update with the same timestamp - shouldn't change anything
+        dataSource.UpdateDatabaseState(DatabaseState.Standby, timeStamp, TimeSpan.Zero);
+        Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState());
+
+        // Update with a new timestamp
+        timeStamp = timeStamp.AddSeconds(1);
+        dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadOnly, timeStamp, TimeSpan.Zero);
+        Assert.AreEqual(DatabaseState.PrimaryReadOnly, dataSource.GetDatabaseState());
+
+        // Expired state returns as Unknown (depending on ignoreExpiration)
+        timeStamp = timeStamp.AddSeconds(1);
+        dataSource.UpdateDatabaseState(DatabaseState.PrimaryReadWrite, timeStamp, TimeSpan.FromSeconds(-1));
+        Assert.AreEqual(DatabaseState.Unknown, dataSource.GetDatabaseState(ignoreExpiration: false));
+        Assert.AreEqual(DatabaseState.PrimaryReadWrite, dataSource.GetDatabaseState(ignoreExpiration: true));
+    }
+
+    [Test]
+    public async Task Offline_state_on_connection_failure()
+    {
+        await using var server = PgPostmasterMock.Start(ConnectionString, startupErrorCode: PostgresErrorCodes.ConnectionFailure);
+        await using var dataSource = server.CreateDataSource();
+        await using var conn = dataSource.CreateConnection();
+
+        var ex = Assert.ThrowsAsync<PostgresException>(conn.OpenAsync)!;
+        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.ConnectionFailure));
+
+        var state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Offline));
+    }
+
+    [Test]
+    public async Task Unknown_state_on_connection_authentication_failure()
+    {
+        await using var server = PgPostmasterMock.Start(ConnectionString, startupErrorCode: PostgresErrorCodes.InvalidAuthorizationSpecification);
+        await using var dataSource = server.CreateDataSource();
+        await using var conn = dataSource.CreateConnection();
+
+        var ex = Assert.ThrowsAsync<PostgresException>(conn.OpenAsync)!;
+        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.InvalidAuthorizationSpecification));
+
+        var state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+    }
+
+    [Test]
+    public async Task Offline_state_on_query_execution_pg_critical_failure()
+    {
+        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+        await using var dataSource = postmaster.CreateDataSource();
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var anotherConn = await dataSource.OpenConnectionAsync();
+        await anotherConn.CloseAsync();
+
+        var state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+
+        var server = await postmaster.WaitForServerConnection();
+        await server.WriteErrorResponse(PostgresErrorCodes.CrashShutdown).FlushAsync();
+
+        var ex = Assert.ThrowsAsync<PostgresException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
+        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.CrashShutdown));
+        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+
+        state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Offline));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
+    }
+
+    [Test, NonParallelizable]
+    public async Task Offline_state_on_query_execution_pg_non_critical_failure()
+    {
+        await using var dataSource = CreateDataSource();
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        // Starting with PG14 we get the cluster's state from PG automatically
+        var expectedState = conn.PostgreSqlVersion.Major > 13 ? DatabaseState.PrimaryReadWrite : DatabaseState.Unknown;
+
+        var state = dataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(expectedState));
+        Assert.That(dataSource.Statistics.Total, Is.EqualTo(1));
+
+        var ex = Assert.ThrowsAsync<PostgresException>(() => conn.ExecuteNonQueryAsync("SELECT abc"))!;
+        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.UndefinedColumn));
+        Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
+
+        state = dataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(expectedState));
+        Assert.That(dataSource.Statistics.Total, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Offline_state_on_query_execution_IOException()
+    {
+        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+        await using var dataSource = postmaster.CreateDataSource();
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var anotherConn = await dataSource.OpenConnectionAsync();
+        await anotherConn.CloseAsync();
+
+        var state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+
+        var server = await postmaster.WaitForServerConnection();
+        server.Close();
+
+        var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
+        Assert.That(ex.InnerException, Is.InstanceOf<IOException>());
+        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+
+        state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Offline));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Offline_state_on_query_execution_TimeoutException()
+    {
+        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+        var dataSourceBuilder = postmaster.GetDataSourceBuilder();
+        dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
+        dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = 1;
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var anotherConn = await dataSource.OpenConnectionAsync();
+        await anotherConn.CloseAsync();
+
+        var state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+
+        var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
+        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+
+        state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Offline));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Unknown_state_on_query_execution_TimeoutException_with_disabled_cancellation()
+    {
+        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+        var dataSourceBuilder = postmaster.GetDataSourceBuilder();
+        dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
+        dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = -1;
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var anotherConn = await dataSource.OpenConnectionAsync();
+        await anotherConn.CloseAsync();
+
+        var state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+
+        var ex = Assert.ThrowsAsync<NpgsqlException>(() => conn.ExecuteNonQueryAsync("SELECT 1"))!;
+        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+
+        state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Unknown_state_on_query_execution_cancellation_with_disabled_cancellation_timeout()
+    {
+        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+        var dataSourceBuilder = postmaster.GetDataSourceBuilder();
+        dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 30;
+        dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = -1;
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await using var conn = await dataSource.OpenConnectionAsync();
+        await using var anotherConn = await dataSource.OpenConnectionAsync();
+        await anotherConn.CloseAsync();
+
+        var state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(2));
+
+        using var cts = new CancellationTokenSource();
+
+        var query = conn.ExecuteNonQueryAsync("SELECT 1", cancellationToken: cts.Token);
+        cts.Cancel();
+        var ex = Assert.ThrowsAsync<OperationCanceledException>(async () => await query)!;
+        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+        Assert.That(conn.State, Is.EqualTo(ConnectionState.Closed));
+
+        state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Unknown_state_on_query_execution_TimeoutException_with_cancellation_failure()
+    {
+        await using var postmaster = PgPostmasterMock.Start(ConnectionString);
+        var dataSourceBuilder = postmaster.GetDataSourceBuilder();
+        dataSourceBuilder.ConnectionStringBuilder.CommandTimeout = 1;
+        dataSourceBuilder.ConnectionStringBuilder.CancellationTimeout = 0;
+        await using var dataSource = dataSourceBuilder.Build();
+
+        await using var conn = await dataSource.OpenConnectionAsync();
+
+        var state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+
+        var server = await postmaster.WaitForServerConnection();
+
+        var query = conn.ExecuteNonQueryAsync("SELECT 1");
+
+        await postmaster.WaitForCancellationRequest();
+        await server.WriteCancellationResponse().WriteReadyForQuery().FlushAsync();
+
+        var ex = Assert.ThrowsAsync<NpgsqlException>(async () => await query)!;
+        Assert.That(ex.InnerException, Is.TypeOf<TimeoutException>());
+        Assert.That(conn.State, Is.EqualTo(ConnectionState.Open));
+
+        state = conn.NpgsqlDataSource.GetDatabaseState();
+        Assert.That(state, Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(conn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Clear_pool_one_host_only_on_admin_shutdown()
+    {
+        await using var primaryPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
+        await using var standbyPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder
+        {
+            ConnectionStringBuilder =
+            {
+                Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+                MaxPoolSize = 2
+            }
+        };
+        await using var multiHostDataSource = dataSourceBuilder.BuildMultiHost();
+        await using var preferPrimaryDataSource = multiHostDataSource.WithTargetSession(TargetSessionAttributes.PreferPrimary);
+
+        await using var primaryConn = await preferPrimaryDataSource.OpenConnectionAsync();
+        await using var anotherPrimaryConn = await preferPrimaryDataSource.OpenConnectionAsync();
+        await using var standbyConn = await preferPrimaryDataSource.OpenConnectionAsync();
+        var primaryDataSource = primaryConn.Connector!.DataSource;
+        var standbyDataSource = standbyConn.Connector!.DataSource;
+        await anotherPrimaryConn.CloseAsync();
+        await standbyConn.CloseAsync();
+
+        Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.PrimaryReadWrite));
+        Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
+        Assert.That(primaryConn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(3));
+
+        var server = await primaryPostmaster.WaitForServerConnection();
+        await server.WriteErrorResponse(PostgresErrorCodes.AdminShutdown).FlushAsync();
+
+        var ex = Assert.ThrowsAsync<PostgresException>(() => primaryConn.ExecuteNonQueryAsync("SELECT 1"))!;
+        Assert.That(ex.SqlState, Is.EqualTo(PostgresErrorCodes.AdminShutdown));
+        Assert.That(primaryConn.State, Is.EqualTo(ConnectionState.Closed));
+
+        Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Offline));
+        Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
+        Assert.That(primaryConn.NpgsqlDataSource.Statistics.Total, Is.EqualTo(1));
+
+        multiHostDataSource.ClearDatabaseStates();
+        Assert.That(primaryDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(standbyDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
+    }
+
+    [Test]
+    [TestCase("any", true)]
+    [TestCase("primary", true)]
+    [TestCase("standby", false)]
+    [TestCase("prefer-primary", true)]
+    [TestCase("prefer-standby", false)]
+    [TestCase("read-write", true)]
+    [TestCase("read-only", false)]
+    public async Task Transaction_enlist_reuses_connection(string targetSessionAttributes, bool primary)
+    {
+        await using var primaryPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
+        await using var standbyPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
+        var csb = new NpgsqlConnectionStringBuilder
+        {
+            Host = MultipleHosts(primaryPostmaster, standbyPostmaster),
+            TargetSessionAttributes = targetSessionAttributes,
+            ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            MaxPoolSize = 10,
+        };
+
+        using var _ = CreateTempPool(csb, out var connString);
+
+        using var scope = new TransactionScope(TransactionScopeOption.Required,
+            new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }, TransactionScopeAsyncFlowOption.Enabled);
+
+        var query1Task = Query(connString);
+
+        var server = primary
+            ? await primaryPostmaster.WaitForServerConnection()
+            : await standbyPostmaster.WaitForServerConnection();
+
+        await server
+            .WriteCommandComplete()
+            .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
+            .WriteParseComplete()
+            .WriteBindComplete()
+            .WriteNoData()
+            .WriteCommandComplete()
+            .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
+            .FlushAsync();
+        await query1Task;
+
+        var query2Task = Query(connString);
+        await server
+            .WriteParseComplete()
+            .WriteBindComplete()
+            .WriteNoData()
+            .WriteCommandComplete()
+            .WriteReadyForQuery(TransactionStatus.InTransactionBlock)
+            .FlushAsync();
+        await query2Task;
+
+        await server
+            .WriteCommandComplete()
+            .WriteReadyForQuery()
+            .FlushAsync();
+        scope.Complete();
+
+        async Task Query(string connectionString)
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT 1";
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    [Test]
+    public async Task Primary_host_failover_can_connect()
+    {
+        await using var firstPostmaster = PgPostmasterMock.Start(ConnectionString, state: Primary);
+        await using var secondPostmaster = PgPostmasterMock.Start(ConnectionString, state: Standby);
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder
+        {
+            ConnectionStringBuilder =
+            {
+                Host = MultipleHosts(firstPostmaster, secondPostmaster),
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+                HostRecheckSeconds = 5
+            }
+        };
+        await using var multiHostDataSource = dataSourceBuilder.BuildMultiHost();
+        var (firstDataSource, secondDataSource) = (multiHostDataSource.Pools[0], multiHostDataSource.Pools[1]);
+        await using var primaryDataSource = multiHostDataSource.WithTargetSession(TargetSessionAttributes.Primary);
+
+        await using var conn = await primaryDataSource.OpenConnectionAsync();
+        Assert.That(conn.Port, Is.EqualTo(firstPostmaster.Port));
+        var firstServer = await firstPostmaster.WaitForServerConnection();
+        await firstServer
+            .WriteErrorResponse(PostgresErrorCodes.AdminShutdown)
+            .FlushAsync();
+
+        var failoverEx = Assert.ThrowsAsync<PostgresException>(async () => await conn.ExecuteNonQueryAsync("SELECT 1"))!;
+        Assert.That(failoverEx.SqlState, Is.EqualTo(PostgresErrorCodes.AdminShutdown));
+
+        var noHostFoundEx = Assert.ThrowsAsync<NpgsqlException>(async () => await conn.OpenAsync())!;
+        Assert.That(noHostFoundEx.Message, Is.EqualTo("No suitable host was found."));
+
+        Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Offline));
+        Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
+
+        firstPostmaster.State = Standby;
+        secondPostmaster.State = Primary;
+        var secondServer = await secondPostmaster.WaitForServerConnection();
+        await secondServer.SendMockState(Primary);
+
+        await Task.Delay(TimeSpan.FromSeconds(10));
+        Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
+        Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Unknown));
+
+        await conn.OpenAsync();
+        Assert.That(conn.Port, Is.EqualTo(secondPostmaster.Port));
+        Assert.That(firstDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.Standby));
+        Assert.That(secondDataSource.GetDatabaseState(), Is.EqualTo(DatabaseState.PrimaryReadWrite));
+    }
+
+    [Test, NonParallelizable]
+    public void IntegrationTest([Values] LoadBalanceHosts loadBalancing, [Values] bool alwaysCheckHostState)
+    {
+        PoolManager.Reset();
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
+        {
+            ConnectionStringBuilder =
+            {
+                Host = "localhost,127.0.0.1",
+                Pooling = true,
+                MaxPoolSize = 2,
+                LoadBalanceHosts = loadBalancing,
+                HostRecheckSeconds = alwaysCheckHostState ? 0 : 10,
+            }
+        };
+        using var dataSource = dataSourceBuilder.BuildMultiHost();
+
+        var queriesDone = 0;
+
+        var clientsTask = Task.WhenAll(
+            Client(dataSource, TargetSessionAttributes.Any),
+            Client(dataSource, TargetSessionAttributes.Primary),
+            Client(dataSource, TargetSessionAttributes.PreferPrimary),
+            Client(dataSource, TargetSessionAttributes.PreferStandby),
+            Client(dataSource, TargetSessionAttributes.ReadWrite));
+
+        var onlyStandbyClient = Client(dataSource, TargetSessionAttributes.Standby);
+        var readOnlyClient = Client(dataSource, TargetSessionAttributes.ReadOnly);
+
+        Assert.DoesNotThrowAsync(() => clientsTask);
+        Assert.ThrowsAsync<NpgsqlException>(() => onlyStandbyClient);
+        Assert.ThrowsAsync<NpgsqlException>(() => readOnlyClient);
+        Assert.AreEqual(125, queriesDone);
+
+        Task Client(NpgsqlMultiHostDataSource multiHostDataSource, TargetSessionAttributes targetSessionAttributes)
+        {
+            var dataSource = multiHostDataSource.WithTargetSession(targetSessionAttributes);
+            var tasks = new List<Task>(5);
+
+            for (var i = 0; i < 5; i++)
+            {
+                tasks.Add(Task.Run(() => Query(dataSource)));
+            }
+
+            return Task.WhenAll(tasks);
+        }
+
+        async Task Query(NpgsqlDataSource dataSource)
+        {
+            await using var conn = dataSource.CreateConnection();
+            for (var i = 0; i < 5; i++)
+            {
+                await conn.OpenAsync();
+                await conn.ExecuteNonQueryAsync("SELECT 1");
+                await conn.CloseAsync();
+                Interlocked.Increment(ref queriesDone);
+            }
+        }
+    }
+
+    [Test]
+    [IssueLink("https://github.com/npgsql/npgsql/issues/5055")]
+    [NonParallelizable] // Disables sql rewriting
+    public async Task Multiple_hosts_with_disabled_sql_rewriting()
+    {
+        using var _ = DisableSqlRewriting();
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(ConnectionString)
+        {
+            ConnectionStringBuilder =
+            {
+                Host = "localhost,127.0.0.1",
+                Pooling = true,
+                HostRecheckSeconds = 0
+            }
+        };
+        await using var dataSource = dataSourceBuilder.BuildMultiHost();
+        await using var conn = await dataSource.OpenConnectionAsync();
+    }
+
+    [Test]
+    public async Task DataSource_with_wrappers()
+    {
+        await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
+        await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
+
+        var builder = new NpgsqlDataSourceBuilder
+        {
+            ConnectionStringBuilder =
+            {
+                Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            }
+        };
+
+        await using var dataSource = builder.BuildMultiHost();
+        await using var primaryDataSource = dataSource.WithTargetSession(TargetSessionAttributes.Primary);
+        await using var standbyDataSource = dataSource.WithTargetSession(TargetSessionAttributes.Standby);
+
+        await using var primaryConnection = await primaryDataSource.OpenConnectionAsync();
+        Assert.That(primaryConnection.Port, Is.EqualTo(primaryPostmasterMock.Port));
+
+        await using var standbyConnection = await standbyDataSource.OpenConnectionAsync();
+        Assert.That(standbyConnection.Port, Is.EqualTo(standbyPostmasterMock.Port));
+    }
+
+    [Test]
+    public async Task DataSource_without_wrappers()
+    {
+        await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
+        await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
+
+        var builder = new NpgsqlDataSourceBuilder
+        {
+            ConnectionStringBuilder =
+            {
+                Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            }
+        };
+
+        await using var dataSource = builder.BuildMultiHost();
+
+        await using var primaryConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Primary);
+        Assert.That(primaryConnection.Port, Is.EqualTo(primaryPostmasterMock.Port));
+
+        await using var standbyConnection = await dataSource.OpenConnectionAsync(TargetSessionAttributes.Standby);
+        Assert.That(standbyConnection.Port, Is.EqualTo(standbyPostmasterMock.Port));
+    }
+
+    [Test]
+    public void DataSource_with_TargetSessionAttributes_is_not_supported()
+    {
+        var builder = new NpgsqlDataSourceBuilder("Host=foo,bar;Target Session Attributes=primary");
+
+        Assert.That(() => builder.BuildMultiHost(), Throws.Exception.TypeOf<InvalidOperationException>()
+            .With.Message.EqualTo(NpgsqlStrings.CannotSpecifyTargetSessionAttributes));
+    }
+
+    [Test]
+    public async Task BuildMultiHost_with_single_host_is_supported()
+    {
+        var builder = new NpgsqlDataSourceBuilder(ConnectionString);
+        await using var dataSource = builder.BuildMultiHost();
+        await using var connection = await dataSource.OpenConnectionAsync();
+        Assert.That(await connection.ExecuteScalarAsync("SELECT 1"), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Build_with_multiple_hosts_is_supported()
+    {
+        await using var primaryPostmasterMock = PgPostmasterMock.Start(state: Primary);
+        await using var standbyPostmasterMock = PgPostmasterMock.Start(state: Standby);
+
+        var builder = new NpgsqlDataSourceBuilder
+        {
+            ConnectionStringBuilder =
+            {
+                Host = MultipleHosts(primaryPostmasterMock, standbyPostmasterMock),
+                ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading,
+            }
+        };
+
+        await using var dataSource = builder.Build();
+        await using var connection = await dataSource.OpenConnectionAsync();
+    }
+
+    [Test, IssueLink("https://github.com/npgsql/npgsql/issues/4181")]
+    [Explicit("Fails until #4181 is fixed.")]
+    public async Task LoadBalancing_is_fair_if_first_host_is_down([Values]TargetSessionAttributes targetSessionAttributes)
+    {
+        await using var pDown = PgPostmasterMock.Start(state: Primary, startupErrorCode: PostgresErrorCodes.CannotConnectNow);
+        await using var pRw1 = PgPostmasterMock.Start(state: Primary);
+        await using var pR1 = PgPostmasterMock.Start(state: PrimaryReadOnly);
+        await using var s1 = PgPostmasterMock.Start(state: Standby);
+        await using var pRw2 = PgPostmasterMock.Start(state: Primary);
+        await using var pR2 = PgPostmasterMock.Start(state: PrimaryReadOnly);
+        await using var s2 = PgPostmasterMock.Start(state: Standby);
+
+        var hostList = $"{pDown.Host}:{pDown.Port}," +
+                       $"{pRw1.Host}:{pRw1.Port}," +
+                       $"{pR1.Host}:{pR1.Port}," +
+                       $"{s1.Host}:{s1.Port}," +
+                       $"{pRw2.Host}:{pRw2.Port}," +
+                       $"{pR2.Host}:{pR2.Port}," +
+                       $"{s2.Host}:{s2.Port}";
+
+        await using var dataSource = CreateDataSource(builder =>
+        {
+            builder.Host = hostList;
+            builder.ServerCompatibilityMode = ServerCompatibilityMode.NoTypeLoading;
+            builder.LoadBalanceHosts = LoadBalanceHosts.True;
+            builder.TargetSessionAttributesParsed = targetSessionAttributes;
+
+        });
+        var connections = Enumerable.Repeat(0, 12).Select(_ => dataSource.OpenConnection()).ToArray();
+        await using var __ = new DisposableWrapper(connections);
+
+        switch (targetSessionAttributes)
+        {
+        case TargetSessionAttributes.Any:
+            Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[1].Port, Is.EqualTo(pR1.Port));
+            Assert.That(connections[2].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[3].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[4].Port, Is.EqualTo(pR2.Port));
+            Assert.That(connections[5].Port, Is.EqualTo(s2.Port));
+            Assert.That(connections[6].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[7].Port, Is.EqualTo(pR1.Port));
+            Assert.That(connections[8].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[9].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[10].Port, Is.EqualTo(pR2.Port));
+            Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
+            break;
+        case TargetSessionAttributes.ReadWrite:
+            Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[1].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[2].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[3].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[4].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[5].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[6].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[7].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[8].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[9].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[10].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[11].Port, Is.EqualTo(pRw2.Port));
+            break;
+        case TargetSessionAttributes.ReadOnly:
+            Assert.That(connections[0].Port, Is.EqualTo(pR1.Port));
+            Assert.That(connections[1].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[2].Port, Is.EqualTo(pR2.Port));
+            Assert.That(connections[3].Port, Is.EqualTo(s2.Port));
+            Assert.That(connections[4].Port, Is.EqualTo(pR1.Port));
+            Assert.That(connections[5].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[6].Port, Is.EqualTo(pR2.Port));
+            Assert.That(connections[7].Port, Is.EqualTo(s2.Port));
+            Assert.That(connections[8].Port, Is.EqualTo(pR1.Port));
+            Assert.That(connections[9].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[10].Port, Is.EqualTo(pR2.Port));
+            Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
+            break;
+        case TargetSessionAttributes.Primary:
+        case TargetSessionAttributes.PreferPrimary:
+            Assert.That(connections[0].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[1].Port, Is.EqualTo(pR1.Port));
+            Assert.That(connections[2].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[3].Port, Is.EqualTo(pR2.Port));
+            Assert.That(connections[4].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[5].Port, Is.EqualTo(pR1.Port));
+            Assert.That(connections[6].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[7].Port, Is.EqualTo(pR2.Port));
+            Assert.That(connections[8].Port, Is.EqualTo(pRw1.Port));
+            Assert.That(connections[9].Port, Is.EqualTo(pR1.Port));
+            Assert.That(connections[10].Port, Is.EqualTo(pRw2.Port));
+            Assert.That(connections[11].Port, Is.EqualTo(pR2.Port));
+            break;
+        case TargetSessionAttributes.Standby:
+        case TargetSessionAttributes.PreferStandby:
+            Assert.That(connections[0].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[1].Port, Is.EqualTo(s2.Port));
+            Assert.That(connections[2].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[3].Port, Is.EqualTo(s2.Port));
+            Assert.That(connections[4].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[5].Port, Is.EqualTo(s2.Port));
+            Assert.That(connections[6].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[7].Port, Is.EqualTo(s2.Port));
+            Assert.That(connections[8].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[9].Port, Is.EqualTo(s2.Port));
+            Assert.That(connections[10].Port, Is.EqualTo(s1.Port));
+            Assert.That(connections[11].Port, Is.EqualTo(s2.Port));
+            break;
+        }
+    }
+
+    static string MultipleHosts(params PgPostmasterMock[] postmasters)
+        => string.Join(",", postmasters.Select(p => $"{p.Host}:{p.Port}"));
+
+    class DisposableWrapper : IAsyncDisposable
+    {
+        readonly IEnumerable<IAsyncDisposable> _disposables;
+
+        public DisposableWrapper(IEnumerable<IAsyncDisposable> disposables) => _disposables = disposables;
+
+        public async ValueTask DisposeAsync()
+        {
+            foreach (var disposable in _disposables)
+                await disposable.DisposeAsync();
+        }
+    }
+}

--- a/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
@@ -20,13 +20,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns / 3);
-            await VerifyOn("127.0.0.2", numConns / 3);
-            await VerifyOn("127.0.0.3", numConns / 3);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, 0, 0, 0});
 
         }
         catch (Exception ex)
@@ -50,13 +44,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns / 3);
-            await VerifyOn("127.0.0.2", numConns / 3);
-            await VerifyOn("127.0.0.3", numConns / 3);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, 0, 0, 0});
 
         }
         catch (Exception ex)
@@ -92,13 +80,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", numConns / 3);
-            await VerifyOn("127.0.0.5", numConns / 3);
-            await VerifyOn("127.0.0.6", numConns / 3);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{-1, -1, -1, numConns / 3, numConns / 3, numConns / 3});
 
         }
         catch (Exception ex)
@@ -121,13 +103,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", numConns / 3);
-            await VerifyOn("127.0.0.5", numConns / 3);
-            await VerifyOn("127.0.0.6", numConns / 3);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns / 3, numConns / 3, numConns / 3});
 
         }
         catch (Exception ex)
@@ -151,13 +127,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", numConns / 3);
-            await VerifyOn("127.0.0.5", numConns / 3);
-            await VerifyOn("127.0.0.6", numConns / 3);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns / 3, numConns / 3, numConns / 3});
 
         }
         catch (Exception ex)
@@ -193,13 +163,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         Console.WriteLine(_Output);
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns / 3);
-            await VerifyOn("127.0.0.2", numConns / 3);
-            await VerifyOn("127.0.0.3", numConns / 3);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, -1, -1, -1});
 
         }
         catch (Exception ex)
@@ -222,13 +186,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns / 6);
-            await VerifyOn("127.0.0.2", numConns / 6);
-            await VerifyOn("127.0.0.3", numConns / 6);
-            await VerifyOn("127.0.0.4", numConns / 6);
-            await VerifyOn("127.0.0.5", numConns / 6);
-            await VerifyOn("127.0.0.6", numConns / 6);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 6, numConns / 6, numConns / 6, numConns / 6, numConns / 6, numConns / 6});
 
         }
         catch (Exception ex)
@@ -242,7 +200,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         }
     }
 
-    static List<NpgsqlConnection> CreateConnections(string connString, int numConns)
+    static async Task<List<NpgsqlConnection>> CreateConnections(string connString, int numConns,  int[] count)
     {
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         try
@@ -255,6 +213,16 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             }
 
             Console.WriteLine("Connections Created");
+            var j = 1;
+            foreach(var expectedCount in count)
+            {
+                if (expectedCount != -1)
+                {
+                    await VerifyOn("127.0.0." + j, expectedCount);
+                }
+
+                j++;
+            }
         }
         catch (Exception ex)
         {

--- a/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
@@ -13,7 +13,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -37,7 +37,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -47,7 +47,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -71,7 +71,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
     [Test]
@@ -80,7 +80,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var connStringBuilder = "host=127.0.0.4;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop node: 127.0.0.1, 127.0.0.2, 127.0.0.3
 
         try
@@ -105,7 +105,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
     [Test]
@@ -114,7 +114,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -138,7 +138,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -148,7 +148,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -172,7 +172,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -182,7 +182,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop node : 127.0.0.4, 127.0.0.5, 127.0.0.6
 
         try
@@ -207,7 +207,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
     [Test]
@@ -216,7 +216,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -240,7 +240,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -267,5 +267,34 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
 
         return conns;
 
+    }
+
+    void CreateRRCluster()
+    {
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/build/latest/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter2.rack1 --tserver_flags placement_uuid=rr";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl add_node--placement_info cloud1.datacenter3.rack1 --tserver_flags placement_uuid=rr";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter4.rack1 --tserver_flags placement_uuid=rr";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+    }
+
+    protected void DestroyCluster()
+    {
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl destroy";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
     }
 }

--- a/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
@@ -36,17 +36,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -76,17 +66,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
     [Test, Timeout(60000)]
@@ -128,17 +108,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
     [Test, Timeout(60000)]
@@ -167,17 +137,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -207,17 +167,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -259,17 +209,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
     [Test, Timeout(60000)]
@@ -298,17 +238,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -364,5 +294,20 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         string? _Error = null;
         var cmd = "/bin/yb-ctl destroy";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
+    }
+
+    void CloseConnections(List<NpgsqlConnection> conns)
+    {
+        foreach (var conn in conns)
+        {
+            conn.Close();
+        }
+        VerifyLocal("127.0.0.1", 0);
+        VerifyLocal("127.0.0.2", 0);
+        VerifyLocal("127.0.0.3", 0);
+        VerifyLocal("127.0.0.4", 0);
+        VerifyLocal("127.0.0.5", 0);
+        VerifyLocal("127.0.0.6", 0);
+        DestroyCluster();
     }
 }

--- a/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace YBNpgsql.Tests;
+
+public class YBClusterAwareRRSupportTests : YBTestUtils{
+    int numConns = 6;
+    [Test]
+    public async Task TestOnlyPrimary()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns / 3);
+            await VerifyOn("127.0.0.2", numConns / 3);
+            await VerifyOn("127.0.0.3", numConns / 3);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferPrimary()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns / 3);
+            await VerifyOn("127.0.0.2", numConns / 3);
+            await VerifyOn("127.0.0.3", numConns / 3);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+    [Test]
+    public async Task TestPreferPrimaryAllNodesDown()
+    {
+        var connStringBuilder = "host=127.0.0.4;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop node: 127.0.0.1, 127.0.0.2, 127.0.0.3
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", numConns / 3);
+            await VerifyOn("127.0.0.5", numConns / 3);
+            await VerifyOn("127.0.0.6", numConns / 3);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+    [Test]
+    public async Task TestOnlyRR()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", numConns / 3);
+            await VerifyOn("127.0.0.5", numConns / 3);
+            await VerifyOn("127.0.0.6", numConns / 3);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferRR()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", numConns / 3);
+            await VerifyOn("127.0.0.5", numConns / 3);
+            await VerifyOn("127.0.0.6", numConns / 3);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferRRAllNodesDown()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop node : 127.0.0.4, 127.0.0.5, 127.0.0.6
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns / 3);
+            await VerifyOn("127.0.0.2", numConns / 3);
+            await VerifyOn("127.0.0.3", numConns / 3);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+    [Test]
+    public async Task TestAny()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns / 6);
+            await VerifyOn("127.0.0.2", numConns / 6);
+            await VerifyOn("127.0.0.3", numConns / 6);
+            await VerifyOn("127.0.0.4", numConns / 6);
+            await VerifyOn("127.0.0.5", numConns / 6);
+            await VerifyOn("127.0.0.6", numConns / 6);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    static List<NpgsqlConnection> CreateConnections(string connString, int numConns)
+    {
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        try
+        {
+            for (var i = 1; i <= numConns; i++)
+            {
+                NpgsqlConnection conn = new NpgsqlConnection(connString);
+                conn.Open();
+                conns.Add(conn);
+            }
+
+            Console.WriteLine("Connections Created");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+            return conns;
+        }
+
+        return conns;
+
+    }
+}

--- a/test/Npgsql.Tests/YBFallbackTopolgyTests.cs
+++ b/test/Npgsql.Tests/YBFallbackTopolgyTests.cs
@@ -143,6 +143,9 @@ public class YBFallbackTopolgyTests : YBTestUtils
                 conn.Close();
             }
         }
+        VerifyLocal("127.0.0.1", 0);
+        VerifyLocal("127.0.0.2", 0);
+        VerifyLocal("127.0.0.3", 0);
     }
 
     protected void CreateCluster()

--- a/test/Npgsql.Tests/YBTestUtils.cs
+++ b/test/Npgsql.Tests/YBTestUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Reflection.Metadata.Ecma335;
@@ -11,8 +12,7 @@ public class YBTestUtils
 {
     public void ExecuteShellCommand(string argument, ref string? _outputMessage, ref string? _errorMessage)
 {
-    // var path = Environment.GetEnvironmentVariable("YBDB_PATH");
-    var path = "/Users/sfurtisarah/code/yugabyte-db";
+    var path = Environment.GetEnvironmentVariable("YBDB_PATH");
     var arguments = path + argument;
     // Set process variable
     // Provides access to local and remote processes and enables you to start and stop local system processes.
@@ -67,7 +67,7 @@ public class YBTestUtils
             var responseBody = await response.Content.ReadAsStringAsync();
             var count = responseBody.Split("client backend");
             Console.WriteLine(server + ":" + (count.Length - 1));
-            // Assert.AreEqual(ExpectedCount, count.Length - 1);
+            Assert.AreEqual(ExpectedCount, count.Length - 1);
 
             // Verify Local
 
@@ -86,7 +86,7 @@ public class YBTestUtils
 
         var recorded = ClusterAwareDataSource.GetLoad(server);
         Console.WriteLine(server + ":" + recorded);
-        // Assert.AreEqual(ExpectedCount, recorded);
+        Assert.AreEqual(ExpectedCount, recorded);
 
     }
 }

--- a/test/Npgsql.Tests/YBTestUtils.cs
+++ b/test/Npgsql.Tests/YBTestUtils.cs
@@ -66,7 +66,7 @@ public class YBTestUtils
             var responseBody = await response.Content.ReadAsStringAsync();
             var count = responseBody.Split("client backend");
             Console.WriteLine(server + ":" + (count.Length - 1));
-            // Assert.AreEqual(ExpectedCount, count.Length - 1);
+            Assert.AreEqual(ExpectedCount, count.Length - 1);
         }
         catch (HttpRequestException e)
         {

--- a/test/Npgsql.Tests/YBTestUtils.cs
+++ b/test/Npgsql.Tests/YBTestUtils.cs
@@ -84,10 +84,7 @@ public class YBTestUtils
     {
         Console.WriteLine("Client side verification:");
 
-        ClusterAwareDataSource? cs = ClusterAwareDataSource.GetInstance();
-
-        Debug.Assert(cs != null, nameof(cs) + " != null");
-        var recorded = cs.GetLoad(server);
+        var recorded = ClusterAwareDataSource.GetLoad(server);
         Console.WriteLine(server + ":" + recorded);
         // Assert.AreEqual(ExpectedCount, recorded);
 

--- a/test/Npgsql.Tests/YBTestUtils.cs
+++ b/test/Npgsql.Tests/YBTestUtils.cs
@@ -11,7 +11,8 @@ public class YBTestUtils
 {
     public void ExecuteShellCommand(string argument, ref string? _outputMessage, ref string? _errorMessage)
 {
-    var path = Environment.GetEnvironmentVariable("YBDB_PATH");
+    // var path = Environment.GetEnvironmentVariable("YBDB_PATH");
+    var path = "/Users/sfurtisarah/code/yugabyte-db";
     var arguments = path + argument;
     // Set process variable
     // Provides access to local and remote processes and enables you to start and stop local system processes.
@@ -66,11 +67,29 @@ public class YBTestUtils
             var responseBody = await response.Content.ReadAsStringAsync();
             var count = responseBody.Split("client backend");
             Console.WriteLine(server + ":" + (count.Length - 1));
-            Assert.AreEqual(ExpectedCount, count.Length - 1);
+            // Assert.AreEqual(ExpectedCount, count.Length - 1);
+
+            // Verify Local
+
+           VerifyLocal(server, ExpectedCount);
+
         }
         catch (HttpRequestException e)
         {
             Console.WriteLine(e.Message);
         }
+    }
+
+    protected static void VerifyLocal(string server, int ExpectedCount)
+    {
+        Console.WriteLine("Client side verification:");
+
+        ClusterAwareDataSource? cs = ClusterAwareDataSource.GetInstance();
+
+        Debug.Assert(cs != null, nameof(cs) + " != null");
+        var recorded = cs.GetLoad(server);
+        Console.WriteLine(server + ":" + recorded);
+        // Assert.AreEqual(ExpectedCount, recorded);
+
     }
 }

--- a/test/Npgsql.Tests/YBTestUtils.cs
+++ b/test/Npgsql.Tests/YBTestUtils.cs
@@ -66,7 +66,7 @@ public class YBTestUtils
             var responseBody = await response.Content.ReadAsStringAsync();
             var count = responseBody.Split("client backend");
             Console.WriteLine(server + ":" + (count.Length - 1));
-            Assert.AreEqual(ExpectedCount, count.Length - 1);
+            // Assert.AreEqual(ExpectedCount, count.Length - 1);
         }
         catch (HttpRequestException e)
         {

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -270,6 +272,25 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             await VerifyOn("127.0.0.4", numConns / 3 );
             await VerifyOn("127.0.0.5", numConns / 3);
             await VerifyOn("127.0.0.6", numConns / 3);
+
+            // Start Node 1
+            _Output = null;
+            _Error = null;
+            cmd = "/bin/yb-ctl start_node 1";
+            ExecuteShellCommand(cmd, ref _Output, ref _Error );
+            Console.WriteLine("Output:" + _Output);
+
+            Thread.Sleep(10000);
+
+            conns.Concat(CreateConnections(connStringBuilder, numConns));
+
+            await VerifyOn("127.0.0.1", numConns);
+            await VerifyOn("127.0.0.2", -1);
+            await VerifyOn("127.0.0.3", -1);
+            await VerifyOn("127.0.0.4", numConns / 3 );
+            await VerifyOn("127.0.0.5", numConns / 3);
+            await VerifyOn("127.0.0.6", numConns / 3);
+
 
         }
         catch (Exception ex)
@@ -683,6 +704,20 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             await VerifyOn("127.0.0.4", -1);
             await VerifyOn("127.0.0.5", -1);
             await VerifyOn("127.0.0.6", -1);
+
+            // Start RR node: 127.0.0.4
+            cmd = "/bin/yb-ctl start_node 4";
+            ExecuteShellCommand(cmd, ref _Output, ref _Error );
+            Console.WriteLine("Output:" + _Output);
+
+            conns.Concat(CreateConnections(connStringBuilder, numConns));
+            await VerifyOn("127.0.0.1", numConns / 3 );
+            await VerifyOn("127.0.0.2", numConns / 3);
+            await VerifyOn("127.0.0.3", numConns / 3);
+            await VerifyOn("127.0.0.4", numConns);
+            await VerifyOn("127.0.0.5", -1);
+            await VerifyOn("127.0.0.6", -1);
+
 
         }
         catch (Exception ex)

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -20,13 +20,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", numConns);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, numConns, 0, 0, 0, 0});
 
         }
         catch (Exception ex)
@@ -59,13 +53,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns);
-            await VerifyOn("127.0.0.2", -1);
-            await VerifyOn("127.0.0.3", -1);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, 0, 0, 0});
 
         }
         catch (Exception ex)
@@ -98,7 +86,12 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
+            for (var i = 1; i <= numConns; i++)
+            {
+                NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder);
+                conn.Open();
+                conns.Add(conn);
+            }
 
         }
         catch (NpgsqlException ex)
@@ -128,13 +121,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", -1);
-            await VerifyOn("127.0.0.3", numConns);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, -1, numConns, 0, 0, 0});
 
         }
         catch (Exception ex)
@@ -158,13 +145,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", numConns);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, numConns, 0, 0, 0, 0});
 
         }
         catch (Exception ex)
@@ -194,14 +175,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", -1);
-            await VerifyOn("127.0.0.3", numConns);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, -1, numConns, 0, 0, 0});
         }
         catch (Exception ex)
         {
@@ -235,13 +209,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", -1);
-            await VerifyOn("127.0.0.2", -1);
-            await VerifyOn("127.0.0.3", -1);
-            await VerifyOn("127.0.0.4", numConns / 3 );
-            await VerifyOn("127.0.0.5", numConns / 3);
-            await VerifyOn("127.0.0.6", numConns / 3);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{-1, -1, -1, numConns / 3, numConns / 3, numConns / 3});
 
             // Start Node 1
             _Output = null;
@@ -251,16 +219,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             Console.WriteLine("Output:" + _Output);
 
             Thread.Sleep(10000);
-
-            conns.Concat(CreateConnections(connStringBuilder, numConns));
-
-            await VerifyOn("127.0.0.1", numConns);
-            await VerifyOn("127.0.0.2", -1);
-            await VerifyOn("127.0.0.3", -1);
-            await VerifyOn("127.0.0.4", numConns / 3 );
-            await VerifyOn("127.0.0.5", numConns / 3);
-            await VerifyOn("127.0.0.6", numConns / 3);
-
+            conns.Concat(await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, numConns / 3, numConns / 3, numConns / 3}));
 
         }
         catch (Exception ex)
@@ -293,13 +252,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns);
-            await VerifyOn("127.0.0.2", -1);
-            await VerifyOn("127.0.0.3", -1);
-            await VerifyOn("127.0.0.4", 0);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, 0, 0, 0});
 
         }
         catch (Exception ex)
@@ -322,14 +275,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", numConns);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns, 0, 0, 0});
         }
         catch (Exception ex)
         {
@@ -358,14 +304,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", -1);
-            await VerifyOn("127.0.0.5", numConns);
-            await VerifyOn("127.0.0.6", 0);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, -1, numConns, 0});
         }
         catch (Exception ex)
         {
@@ -397,14 +336,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", -1);
-            await VerifyOn("127.0.0.5", -1);
-            await VerifyOn("127.0.0.6", numConns);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, -1, -1, numConns});
         }
         catch (Exception ex)
         {
@@ -436,7 +368,12 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
+            for (var i = 1; i <= numConns; i++)
+            {
+                NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder);
+                conn.Open();
+                conns.Add(conn);
+            }
 
         }
         catch (NpgsqlException ex)
@@ -460,14 +397,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", numConns);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns, 0, 0});
         }
         catch (Exception ex)
         {
@@ -496,14 +426,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", -1);
-            await VerifyOn("127.0.0.5", numConns);
-            await VerifyOn("127.0.0.6", 0);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, -1, numConns, 0});
         }
         catch (Exception ex)
         {
@@ -535,14 +458,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", 0);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", -1);
-            await VerifyOn("127.0.0.5", -1);
-            await VerifyOn("127.0.0.6", numConns);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, -1, -1, numConns});
         }
         catch (Exception ex)
         {
@@ -577,27 +493,14 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns / 3 );
-            await VerifyOn("127.0.0.2", numConns / 3);
-            await VerifyOn("127.0.0.3", numConns / 3);
-            await VerifyOn("127.0.0.4", -1);
-            await VerifyOn("127.0.0.5", -1);
-            await VerifyOn("127.0.0.6", -1);
+            conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, -1, -1, -1});
 
             // Start RR node: 127.0.0.4
             cmd = "/bin/yb-ctl start_node 4";
             ExecuteShellCommand(cmd, ref _Output, ref _Error );
             Console.WriteLine("Output:" + _Output);
 
-            conns.Concat(CreateConnections(connStringBuilder, numConns));
-            await VerifyOn("127.0.0.1", numConns / 3 );
-            await VerifyOn("127.0.0.2", numConns / 3);
-            await VerifyOn("127.0.0.3", numConns / 3);
-            await VerifyOn("127.0.0.4", numConns);
-            await VerifyOn("127.0.0.5", -1);
-            await VerifyOn("127.0.0.6", -1);
-
+            conns.Concat(await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, numConns, -1, -1}));
 
         }
         catch (Exception ex)
@@ -620,14 +523,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", numConns / 2);
-            await VerifyOn("127.0.0.3", 0);
-            await VerifyOn("127.0.0.4", numConns / 2);
-            await VerifyOn("127.0.0.5", 0);
-            await VerifyOn("127.0.0.6", 0);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, numConns / 2, 0, numConns / 2, 0, 0});
         }
         catch (Exception ex)
         {
@@ -659,14 +555,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", 0);
-            await VerifyOn("127.0.0.2", -1);
-            await VerifyOn("127.0.0.3", numConns /2);
-            await VerifyOn("127.0.0.4", -1);
-            await VerifyOn("127.0.0.5", numConns / 2);
-            await VerifyOn("127.0.0.6", 0);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{0, -1, numConns /2, -1, numConns / 2, 0});
         }
         catch (Exception ex)
         {
@@ -704,7 +593,12 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
+            for (var i = 1; i <= numConns; i++)
+            {
+                NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder);
+                conn.Open();
+                conns.Add(conn);
+            }
 
         }
         catch (NpgsqlException ex)
@@ -743,14 +637,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns /2);
-            await VerifyOn("127.0.0.2", -1);
-            await VerifyOn("127.0.0.3", -1);
-            await VerifyOn("127.0.0.4", -1);
-            await VerifyOn("127.0.0.5", -1);
-            await VerifyOn("127.0.0.6", numConns /2);
-
+            conns = await CreateConnections(connStringBuilder, numConns, new []{numConns /2 , -1, -1, -1, -1, numConns / 2});
         }
         catch (Exception ex)
         {
@@ -763,7 +650,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
     }
 
-    static List<NpgsqlConnection> CreateConnections(string connString, int numConns)
+    static async Task<List<NpgsqlConnection>> CreateConnections(string connString, int numConns,  int[] count)
     {
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         try
@@ -776,6 +663,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             }
 
             Console.WriteLine("Connections Created");
+
+            var j = 1;
+            foreach(var expectedCount in count)
+            {
+                if (expectedCount != -1)
+                {
+                    await VerifyOn("127.0.0." + j, expectedCount);
+                }
+
+                j++;
+            }
         }
         catch (Exception ex)
         {

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -1,0 +1,709 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace YBNpgsql.Tests;
+
+public class YBTopologyAwareRRSupportTests : YBTestUtils
+{
+     int numConns = 6;
+    [Test]
+    public async Task TestOnlyPrimary()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", numConns);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestOnlyPrimaryAllNodesDownAllPlacement()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop node : 127.0.0.2, 127.0.0.3
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns);
+            await VerifyOn("127.0.0.2", -1);
+            await VerifyOn("127.0.0.3", -1);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public void TestOnlyPrimaryAllNodesDownInAllPlacementsFallBackToTopologyOnly()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;FallBack To Topology Keys Only=true;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop node : 127.0.0.2, 127.0.0.3
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+
+        }
+        catch (NpgsqlException ex)
+        {
+            if (ex.Message.Equals("No suitable host was found", StringComparison.OrdinalIgnoreCase))
+                Console.WriteLine("Expected Failure:" + ex.Message);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestOnlyPrimaryAllNodesDownPrimarylacement()
+    {
+        var connStringBuilder = "host=127.0.0.3;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop node : 127.0.0.2
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", -1);
+            await VerifyOn("127.0.0.3", numConns);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferPrimary()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", numConns);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferPrimaryAllNodesDownPrimaryPlacement()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop node : 127.0.0.2
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", -1);
+            await VerifyOn("127.0.0.3", numConns);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+    [Test]
+    public async Task? TestPreferPrimaryAllPrimaryNodesDown()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.1, 127.0.0.2, 127.0.0.3
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", -1);
+            await VerifyOn("127.0.0.2", -1);
+            await VerifyOn("127.0.0.3", -1);
+            await VerifyOn("127.0.0.4", numConns / 3 );
+            await VerifyOn("127.0.0.5", numConns / 3);
+            await VerifyOn("127.0.0.6", numConns / 3);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferPrimaryAllNodesDownAllPlacement()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop node : 127.0.0.2, 127.0.0.3
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns);
+            await VerifyOn("127.0.0.2", -1);
+            await VerifyOn("127.0.0.3", -1);
+            await VerifyOn("127.0.0.4", 0);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+    [Test]
+    public async Task TestOnlyRR()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", numConns);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestOnlyRRAllNodesDownInPrimaryPlacement()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.4
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", -1);
+            await VerifyOn("127.0.0.5", numConns);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestOnlyRRAllNodesDownInAllPlacement()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.4, 127.0.0.5
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", -1);
+            await VerifyOn("127.0.0.5", -1);
+            await VerifyOn("127.0.0.6", numConns);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public void TestOnlyRRAllNodesDownInAllPlacementsFallBackToTopologyOnly()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;FallBack To Topology Keys Only=true;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.4, 127.0.0.5
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+
+        }
+        catch (NpgsqlException ex)
+        {
+            if (ex.Message.Equals("No suitable host was found", StringComparison.OrdinalIgnoreCase))
+                Console.WriteLine("Expected Failure:" + ex.Message);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferRR()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", numConns);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferRRAllNodesDownInPrimaryPlacement()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.4
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", -1);
+            await VerifyOn("127.0.0.5", numConns);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestPreferRRAllNodesDownInAllPlacements()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.4, 127.0.0.5
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", 0);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", -1);
+            await VerifyOn("127.0.0.5", -1);
+            await VerifyOn("127.0.0.6", numConns);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task? TestPreferRRAllRRNodesDown()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.4, 127.0.0.5, 127.0.0.6
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns / 3 );
+            await VerifyOn("127.0.0.2", numConns / 3);
+            await VerifyOn("127.0.0.3", numConns / 3);
+            await VerifyOn("127.0.0.4", -1);
+            await VerifyOn("127.0.0.5", -1);
+            await VerifyOn("127.0.0.6", -1);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+    [Test]
+    public async Task TestAny()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", numConns / 2);
+            await VerifyOn("127.0.0.3", 0);
+            await VerifyOn("127.0.0.4", numConns / 2);
+            await VerifyOn("127.0.0.5", 0);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestAnyAllNodesDownPrimaryPlacement()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.2, 127.0.0.4
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", 0);
+            await VerifyOn("127.0.0.2", -1);
+            await VerifyOn("127.0.0.3", numConns /2);
+            await VerifyOn("127.0.0.4", -1);
+            await VerifyOn("127.0.0.5", numConns / 2);
+            await VerifyOn("127.0.0.6", 0);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public void TestAnyAllNodesDownAllPlacementFallBackToTopologyOnly()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2; FallBack To Topology Keys Only=true;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.2, 127.0.0.3, 127.0.0.4, 127.0.0.5
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+
+        }
+        catch (NpgsqlException ex)
+        {
+            if (ex.Message.Equals("No suitable host was found", StringComparison.OrdinalIgnoreCase))
+                Console.WriteLine("Expected Failure:" + ex.Message);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    [Test]
+    public async Task TestAnyAllNodesDownAllPlacement()
+    {
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        // CreateCluster();
+        // Stop Node: 127.0.0.2, 127.0.0.3, 127.0.0.4, 127.0.0.5
+
+        try
+        {
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns /2);
+            await VerifyOn("127.0.0.2", -1);
+            await VerifyOn("127.0.0.3", -1);
+            await VerifyOn("127.0.0.4", -1);
+            await VerifyOn("127.0.0.5", -1);
+            await VerifyOn("127.0.0.6", numConns /2);
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            // DestroyCluster();
+        }
+    }
+
+    static List<NpgsqlConnection> CreateConnections(string connString, int numConns)
+    {
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        try
+        {
+            for (var i = 1; i <= numConns; i++)
+            {
+                NpgsqlConnection conn = new NpgsqlConnection(connString);
+                conn.Open();
+                conns.Add(conn);
+            }
+
+            Console.WriteLine("Connections Created");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+            return conns;
+        }
+
+        return conns;
+
+    }
+}

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -14,7 +14,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -38,7 +38,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -48,8 +48,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop node : 127.0.0.2, 127.0.0.3
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 3";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -73,7 +81,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -83,8 +91,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;FallBack To Topology Keys Only=true;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop node : 127.0.0.2, 127.0.0.3
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 3";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -102,7 +118,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -112,8 +128,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.3;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop node : 127.0.0.2
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -137,7 +158,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -147,7 +168,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -171,7 +192,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -181,8 +202,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop node : 127.0.0.2
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -206,7 +232,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
     [Test]
@@ -215,8 +241,19 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.1, 127.0.0.2, 127.0.0.3
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 1";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 3";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -240,7 +277,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -250,8 +287,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop node : 127.0.0.2, 127.0.0.3
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 3";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -275,7 +320,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
     [Test]
@@ -284,7 +329,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -308,7 +353,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -318,8 +363,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.4
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -343,7 +393,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -353,8 +403,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.4, 127.0.0.5
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 5";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -378,7 +436,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -388,8 +446,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;FallBack To Topology Keys Only=true;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.4, 127.0.0.5
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 5";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -407,7 +473,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -417,7 +483,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -441,7 +507,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -451,8 +517,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.4
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -476,7 +547,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -486,8 +557,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.4, 127.0.0.5
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 5";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -511,7 +590,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -521,8 +600,19 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.4, 127.0.0.5, 127.0.0.6
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 5";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 6";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -546,7 +636,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
     [Test]
@@ -555,7 +645,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
 
         try
         {
@@ -579,7 +669,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -589,8 +679,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.2, 127.0.0.4
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -614,7 +712,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -624,8 +722,22 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2; FallBack To Topology Keys Only=true;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.2, 127.0.0.3, 127.0.0.4, 127.0.0.5
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 3";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 5";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -643,7 +755,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -653,8 +765,22 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateRRCluster();
         // Stop Node: 127.0.0.2, 127.0.0.3, 127.0.0.4, 127.0.0.5
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl stop_node 2";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 3";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 4";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl stop_node 5";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
 
         try
         {
@@ -678,7 +804,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
-            // DestroyCluster();
+            DestroyCluster();
         }
     }
 
@@ -705,5 +831,34 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
         return conns;
 
+    }
+
+    void CreateRRCluster()
+    {
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/build/latest/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter2.rack1 --tserver_flags placement_uuid=rr";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl add_node--placement_info cloud1.datacenter3.rack1 --tserver_flags placement_uuid=rr";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter4.rack1 --tserver_flags placement_uuid=rr";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+    }
+
+    protected void DestroyCluster()
+    {
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl destroy";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
     }
 }

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -36,11 +36,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -79,11 +75,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -116,11 +108,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -156,11 +144,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -190,11 +174,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -230,17 +210,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
     [Test, Timeout(60000)]
@@ -300,17 +270,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -349,17 +309,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
     [Test, Timeout(60000)]
@@ -388,17 +338,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -434,17 +374,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -483,17 +413,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -526,17 +446,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -566,17 +476,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -612,17 +512,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -661,17 +551,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -727,17 +607,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
     [Test, Timeout(60000)]
@@ -766,17 +636,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -815,17 +675,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -864,17 +714,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+            CloseConnections(conns);
         }
     }
 
@@ -919,17 +759,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
         finally
         {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            VerifyLocal("127.0.0.4", 0);
-            VerifyLocal("127.0.0.5", 0);
-            VerifyLocal("127.0.0.6", 0);
-            DestroyCluster();
+           CloseConnections(conns);
         }
     }
 
@@ -985,5 +815,20 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         string? _Error = null;
         var cmd = "/bin/yb-ctl destroy";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
+    }
+
+    void CloseConnections(List<NpgsqlConnection> conns)
+    {
+        foreach (var conn in conns)
+        {
+            conn.Close();
+        }
+        VerifyLocal("127.0.0.1", 0);
+        VerifyLocal("127.0.0.2", 0);
+        VerifyLocal("127.0.0.3", 0);
+        VerifyLocal("127.0.0.4", 0);
+        VerifyLocal("127.0.0.5", 0);
+        VerifyLocal("127.0.0.6", 0);
+        DestroyCluster();
     }
 }

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -8,7 +8,7 @@ namespace YBNpgsql.Tests;
 public class YBTopologyAwareRRSupportTests : YBTestUtils
 {
      int numConns = 6;
-    [Test]
+     [Test, Timeout(60000)]
     public async Task TestOnlyPrimary()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -42,7 +42,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestOnlyPrimaryAllNodesDownAllPlacement()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -85,7 +85,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public void TestOnlyPrimaryAllNodesDownInAllPlacementsFallBackToTopologyOnly()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;FallBack To Topology Keys Only=true;Timeout=0";
@@ -122,7 +122,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestOnlyPrimaryAllNodesDownPrimarylacement()
     {
         var connStringBuilder = "host=127.0.0.3;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -162,7 +162,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestPreferPrimary()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -196,7 +196,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestPreferPrimaryAllNodesDownPrimaryPlacement()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -232,10 +232,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
-    [Test]
+    [Test, Timeout(60000)]
     public async Task? TestPreferPrimaryAllPrimaryNodesDown()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -277,11 +283,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestPreferPrimaryAllNodesDownAllPlacement()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary; Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -320,10 +332,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestOnlyRR()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -353,11 +371,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestOnlyRRAllNodesDownInPrimaryPlacement()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -393,11 +417,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestOnlyRRAllNodesDownInAllPlacement()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -436,11 +466,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public void TestOnlyRRAllNodesDownInAllPlacementsFallBackToTopologyOnly()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=onlyrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;FallBack To Topology Keys Only=true;Timeout=0";
@@ -473,11 +509,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestPreferRR()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -507,11 +549,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestPreferRRAllNodesDownInPrimaryPlacement()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -547,11 +595,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestPreferRRAllNodesDownInAllPlacements()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -590,11 +644,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task? TestPreferRRAllRRNodesDown()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -636,10 +696,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestAny()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -669,11 +735,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestAnyAllNodesDownPrimaryPlacement()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -712,11 +784,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public void TestAnyAllNodesDownAllPlacementFallBackToTopologyOnly()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2; FallBack To Topology Keys Only=true;Timeout=0";
@@ -755,11 +833,17 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestAnyAllNodesDownAllPlacement()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=any;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
@@ -804,6 +888,12 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             {
                 conn.Close();
             }
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            VerifyLocal("127.0.0.4", 0);
+            VerifyLocal("127.0.0.5", 0);
+            VerifyLocal("127.0.0.6", 0);
             DestroyCluster();
         }
     }


### PR DESCRIPTION
## Why
- Currently, the smart driver does not distinguish between primary nodes and read-replica nodes while distributing the connections.
- Such a mechanism is required when client wants to have one app talk to read-replica nodes only while another one communicates with primary cluster
- The [IDEA ticket](https://yugabyte.atlassian.net/browse/IDEA-1198) 

## What
- Here is [the doc](https://docs.google.com/document/d/11CJmlJdsqiR0HtSUkyW5_riCkwh7vAcirERUPpcqc2w/edit#heading=h.brny7dodp36q) which provides the details about the design.

## Testing
- Added test cases in repository itself.
