### PR TITLE
Fix for the race condition being created when two threads were simultaneously doing refresh

### DIFF
--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -175,18 +175,15 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
 
         lock (SetupDataSourceLock)
         {
-            if (PoolManager.Pools.TryGetValue(_connectionString, out _dataSource) && _dataSource.NeedsRefresh())
+            if (PoolManager.Pools.TryGetValue(_connectionString, out _dataSource))
             {
-                _dataSource.Refresh();
+                if (_dataSource.NeedsRefresh())
+                {
+                    _dataSource.Refresh();
+                }
                 Settings = _dataSource.Settings;  // Great, we already have a pool
                 return;
             }
-        }
-        // Fast path: a pool already corresponds to this exact version of the connection string.
-        if (PoolManager.Pools.TryGetValue(_connectionString, out _dataSource) && !_dataSource.NeedsRefresh())
-        {
-            Settings = _dataSource.Settings;  // Great, we already have a pool
-            return;
         }
 
 
@@ -210,27 +207,21 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
 
         lock (SetupDataSourceLock)
         {
-            if (PoolManager.Pools.TryGetValue(canonical, out _dataSource) && _dataSource.NeedsRefresh())
+            if (PoolManager.Pools.TryGetValue(canonical, out _dataSource))
             {
-                _dataSource.Refresh();
+                if (_dataSource.NeedsRefresh())
+                {
+                    _dataSource.Refresh();
+                }
+                // If this is a multi-host data source and the user specified a TargetSessionAttributes, create a wrapper in front of the
+                // MultiHostDataSource with that TargetSessionAttributes.
+                if (_dataSource is NpgsqlMultiHostDataSource multiHostDataSource && settings.TargetSessionAttributesParsed.HasValue)
+                    _dataSource = multiHostDataSource.WithTargetSession(settings.TargetSessionAttributesParsed.Value);
                 // The pool was found, but only under the canonical key - we're using a different version
                 // for the first time. Map it via our own key for next time.
                 _dataSource = PoolManager.Pools.GetOrAdd(_connectionString, _dataSource);
                 return;
             }
-        }
-
-        if (PoolManager.Pools.TryGetValue(canonical, out _dataSource) && !_dataSource.NeedsRefresh())
-        {
-            // If this is a multi-host data source and the user specified a TargetSessionAttributes, create a wrapper in front of the
-            // MultiHostDataSource with that TargetSessionAttributes.
-            if (_dataSource is NpgsqlMultiHostDataSource multiHostDataSource && settings.TargetSessionAttributesParsed.HasValue)
-                _dataSource = multiHostDataSource.WithTargetSession(settings.TargetSessionAttributesParsed.Value);
-
-            // The pool was found, but only under the canonical key - we're using a different version
-            // for the first time. Map it via our own key for next time.
-            _dataSource = PoolManager.Pools.GetOrAdd(_connectionString, _dataSource);
-            return;
         }
 
         // Really unseen, need to create a new pool

--- a/src/Npgsql/NpgsqlConnection.cs
+++ b/src/Npgsql/NpgsqlConnection.cs
@@ -168,8 +168,20 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
     /// <returns>A task representing the asynchronous operation.</returns>
     public override Task OpenAsync(CancellationToken cancellationToken) => Open(async: true, cancellationToken);
 
+    static readonly object SetupDataSourceLock = new();
     void SetupDataSource()
     {
+        // A pool already corresponds to this version of string but also needs Refresh
+
+        lock (SetupDataSourceLock)
+        {
+            if (PoolManager.Pools.TryGetValue(_connectionString, out _dataSource) && _dataSource.NeedsRefresh())
+            {
+                _dataSource.Refresh();
+                Settings = _dataSource.Settings;  // Great, we already have a pool
+                return;
+            }
+        }
         // Fast path: a pool already corresponds to this exact version of the connection string.
         if (PoolManager.Pools.TryGetValue(_connectionString, out _dataSource) && !_dataSource.NeedsRefresh())
         {
@@ -177,14 +189,6 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
             return;
         }
 
-        // A pool already corresponds to this version of string but also needs Refresh
-
-        if (PoolManager.Pools.TryGetValue(_connectionString, out _dataSource) && _dataSource.NeedsRefresh())
-        {
-            _dataSource.Refresh();
-            Settings = _dataSource.Settings;  // Great, we already have a pool
-            return;
-        }
 
         // Connection string hasn't been seen before. Check for empty and parse (slow one-time path).
         if (_connectionString == string.Empty)
@@ -204,6 +208,18 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
         // Note that we remove TargetSessionAttributes to make all connection strings that are otherwise identical point to the same pool.
         var canonical = settings.ConnectionStringForMultipleHosts;
 
+        lock (SetupDataSourceLock)
+        {
+            if (PoolManager.Pools.TryGetValue(canonical, out _dataSource) && _dataSource.NeedsRefresh())
+            {
+                _dataSource.Refresh();
+                // The pool was found, but only under the canonical key - we're using a different version
+                // for the first time. Map it via our own key for next time.
+                _dataSource = PoolManager.Pools.GetOrAdd(_connectionString, _dataSource);
+                return;
+            }
+        }
+
         if (PoolManager.Pools.TryGetValue(canonical, out _dataSource) && !_dataSource.NeedsRefresh())
         {
             // If this is a multi-host data source and the user specified a TargetSessionAttributes, create a wrapper in front of the
@@ -211,15 +227,6 @@ public sealed class NpgsqlConnection : DbConnection, ICloneable, IComponent
             if (_dataSource is NpgsqlMultiHostDataSource multiHostDataSource && settings.TargetSessionAttributesParsed.HasValue)
                 _dataSource = multiHostDataSource.WithTargetSession(settings.TargetSessionAttributesParsed.Value);
 
-            // The pool was found, but only under the canonical key - we're using a different version
-            // for the first time. Map it via our own key for next time.
-            _dataSource = PoolManager.Pools.GetOrAdd(_connectionString, _dataSource);
-            return;
-        }
-
-        if (PoolManager.Pools.TryGetValue(canonical, out _dataSource) && _dataSource.NeedsRefresh())
-        {
-            _dataSource.Refresh();
             // The pool was found, but only under the canonical key - we're using a different version
             // for the first time. Map it via our own key for next time.
             _dataSource = PoolManager.Pools.GetOrAdd(_connectionString, _dataSource);


### PR DESCRIPTION
In the Refresh() function initialHosts list is being read by one thread while the other thread might be removing an unreachable host from it, mutating the list.
```
 internal override bool Refresh()
    {
       
        initialHosts = initialHosts.Distinct().ToList();
        foreach (var host in initialHosts.ToList())
        {
            try
            {
                // Setting up control connection with host and doing refresh 
            }
            catch (Exception)
            {
               // if host connection fails remove it from the initialHosts list
                _connectionLogger.LogDebug("Failed to connect to {host}", host);
                initialHosts.Remove(host);
                if (initialHosts.Count == 0)
                {
                    _connectionLogger.LogError("Failed to create control connection. No suitable host found");
                    throw;
                }

            }

        }
        unreachableHostsIndices.Clear();
        unreachableHosts.Clear();
        return true;
    }
```

This is creating the following race condition and throwing the error:
```
System.ArgumentException: Source array was not long enough. Check the source index, length, and the array's lower bounds. (Parameter 'sourceArray')
   at System.Array.CopyImpl(Array sourceArray, Int32 sourceIndex, Array destinationArray, Int32 destinationIndex, Int32 length, Boolean reliable)
   at System.Collections.Generic.List`1.set_Capacity(Int32 value)
   at System.Collections.Generic.List`1.AddRange(IEnumerable`1 collection)
   at YBNpgsql.ClusterAwareDataSource.Refresh()
   at YBNpgsql.NpgsqlConnection.SetupDataSource()
```

This fix sets up a lock before needsRefresh() is called so that only one thread actually does the refresh, the other threads can move past this step.

**Testing**

Tested it with a multithreaded application that was long running and read from the database. A shell script was used to periodically down and restart the server nodes. 