### PR TITLE
Add support for maintaining different connector lists for different connection string 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>9.0.2.1</VersionPrefix>
+    <VersionPrefix>9.0.2.2</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,71 @@
+# Npgsql YugabyteDB - the .NET data provider for YugabyteDB
+
+
+Yugabyte Npgsql driver is a distributed .NET driver for YSQL built on the PostgreSQL Npgsql driver. Although the upstream PostgreSQL driver works with YugabyteDB, the Yugabyte driver enhances YugabyteDB by eliminating the need for external load balancers.
+
+* It is cluster-aware, which eliminates the need for an external load balancer.
+* It is topology-aware, which is essential for geographically-distributed applications. The driver uses servers that are part of a set of geo-locations specified by topology keys.
+
+### Load balancing
+
+The Yugabyte Npgsql driver has the following load balancing features:
+
+* Uniform load balancing
+
+In this mode, the driver makes the best effort to uniformly distribute the connections to each YugabyteDB server. For example, if a client application creates 100 connections to a YugabyteDB cluster consisting of 10 servers, then the driver creates 10 connections to each server. If the number of connections are not exactly divisible by the number of servers, then a few may have 1 less or 1 more connection than the others. This is the client view of the load, so the servers may not be well balanced if other client applications are not using the Yugabyte JDBC driver.
+
+* Topology-aware load balancing
+
+Because YugabyteDB clusters can have servers in different regions and availability zones, the YugabyteDB JDBC driver is topology-aware, and can be configured to create connections only on servers that are in specific regions and zones. This is useful for client applications that need to connect to the geographically nearest regions and availability zone for lower latency; the driver tries to uniformly load only those servers that belong to the specified regions and zone.
+
+### Usage
+
+Load balancing connection properties:
+
+The following connection properties are added to enable load balancing:
+
+* Load Balance Hosts - Starting with version 8.0.3.2, it expects one of False, Any (same as true), OnlyPrimary, OnlyRR, PreferPrimary and PreferRR as its possible values.
+  * False - No connection load balancing. Behaviour is similar to vanilla Npgsql driver
+  * Any - Same as value true. Distribute connections equally across all nodes in the cluster, irrespective of its type (primary or read-replica)
+  * OnlyPrimary - Create connections equally across only the primary nodes of the cluster
+  * OnlyRR - Create connections equally across only the read-replica nodes of the cluster
+  * PreferPrimary - Create connections equally across primary cluster nodes. If none available, on any available read replica node in the cluster
+  * PreferRR - Create connections equally across read replica nodes of the cluster. If none available, on any available primary cluster node
+* Topology Keys - provide comma-separated geo-location values to enable topology-aware load balancing. Geo-locations can be provided as cloud.region.zone.
+* YB Servers Refresh Interval - The list of servers, to balance the connection load on, are refreshed periodically every 5 minutes by default. This time can be regulated by this property.
+* Fallback To Topology Keys Only - Decides if the driver can fall back to nodes outside of the given placements for new connections, if the nodes in the given placements are not available. Value true means stick to explicitly given placements for fallback, else fail. Value false means fall back to entire cluster nodes when nodes in the given placements are unavailable. Default is false. It is ignored if topology-keys is not specified or load-balance is set to either prefer-primary or prefer-rr.
+* Failed Host Reconnect Delay Sec - When the driver cannot connect to a server, it marks it as failed with a timestamp. Later, whenever it refreshes the server list via yb_servers(), if it sees the failed server in the response, it marks the server as UP only if the time specified via this property has elapsed since the time it was last marked as a failed host. Default is 5 seconds.
+* Enable Discard Sequence - Flag to enable/disable running `Discard sequences` on connection Reset
+* Enable Discard Temp - Flag to enable/disable running `Discard Temp` on connection Reset
+* Enable Close All - Flag to enable/disable running `Close All` on connection Reset
+* Enable Discard Al - Flag to enable/disable running `Discard All` on connection Reset
+
+Pass new connection properties for load balancing in the connection string. To enable uniform load balancing across all servers, you set the `Load Balance Hosts` property to True in the URL, as per the following example.
+
+Connection String::
+
+```csharp
+var connString = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0";
+```
+
+#### Note: The behaviour of `Load Balance Hosts` is different in YugabyteDB Npgsql Driver as compared to the upstream driver. The upstream driver balances connections on the list of hosts provided in the `host` property while the YugabyteDB Npgsql Driver balances the connections on the list of servers returned by the `yb_servers()` function.
+
+To specify topology keys, you set the `Topology Keys` property to comma separated values, as per the following example.
+
+Connection String::
+
+```csharp
+var connString = "host=127.0.0.3;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0;Topology Keys=cloud.region.zone";
+```
+
+Multiple topologies can also be passed to the Topology Keys property, and each of them can also be given a preference value, as per the following example.
+
+```csharp
+var connString = "host=127.0.0.3;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0;Topology Keys=cloud1.region1.zone1:1,cloud2.region2.zone2:2";
+```
+
+### ----------------------------------- Upstream ReadMe Follows --------------------------------------
+
 # Npgsql - the .NET data provider for PostgreSQL
 
 [![stable](https://img.shields.io/nuget/v/Npgsql.svg?label=stable)](https://www.nuget.org/packages/Npgsql/)
@@ -51,69 +119,3 @@ await using (var reader = await cmd.ExecuteReaderAsync())
 * Great integration with Entity Framework Core via [Npgsql.EntityFrameworkCore.PostgreSQL](https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL).
 
 For the full documentation, please visit the Npgsql website at [https://www.npgsql.org](https://www.npgsql.org).
-
-## YugabyteDB Npgsql Features
-
-
-Yugabyte Npgsql driver is a distributed .NET driver for YSQL built on the PostgreSQL Npgsql driver. Although the upstream PostgreSQL driver works with YugabyteDB, the Yugabyte driver enhances YugabyteDB by eliminating the need for external load balancers.
-
-* It is cluster-aware, which eliminates the need for an external load balancer.
-* It is topology-aware, which is essential for geographically-distributed applications. The driver uses servers that are part of a set of geo-locations specified by topology keys.
-
-### Load balancing
-
-The Yugabyte Npgsql driver has the following load balancing features:
-
-* Uniform load balancing
-
-In this mode, the driver makes the best effort to uniformly distribute the connections to each YugabyteDB server. For example, if a client application creates 100 connections to a YugabyteDB cluster consisting of 10 servers, then the driver creates 10 connections to each server. If the number of connections are not exactly divisible by the number of servers, then a few may have 1 less or 1 more connection than the others. This is the client view of the load, so the servers may not be well balanced if other client applications are not using the Yugabyte JDBC driver.
-
-* Topology-aware load balancing
-
-Because YugabyteDB clusters can have servers in different regions and availability zones, the YugabyteDB JDBC driver is topology-aware, and can be configured to create connections only on servers that are in specific regions and zones. This is useful for client applications that need to connect to the geographically nearest regions and availability zone for lower latency; the driver tries to uniformly load only those servers that belong to the specified regions and zone.
-
-### Usage
-
-Load balancing connection properties:
-
-The following connection properties are added to enable load balancing:
-
-* Load Balance Hosts - Starting with version 8.0.3.2, it expects one of False, Any (same as true), OnlyPrimary, OnlyRR, PreferPrimary and PreferRR as its possible values.
-    * False - No connection load balancing. Behaviour is similar to vanilla Npgsql driver
-    * Any - Same as value true. Distribute connections equally across all nodes in the cluster, irrespective of its type (primary or read-replica)
-    * OnlyPrimary - Create connections equally across only the primary nodes of the cluster
-    * OnlyRR - Create connections equally across only the read-replica nodes of the cluster
-    * PreferPrimary - Create connections equally across primary cluster nodes. If none available, on any available read replica node in the cluster
-    * PreferRR - Create connections equally across read replica nodes of the cluster. If none available, on any available primary cluster node
-* Topology Keys - provide comma-separated geo-location values to enable topology-aware load balancing. Geo-locations can be provided as cloud.region.zone.
-* YB Servers Refresh Interval - The list of servers, to balance the connection load on, are refreshed periodically every 5 minutes by default. This time can be regulated by this property.
-* Fallback To Topology Keys Only - Decides if the driver can fall back to nodes outside of the given placements for new connections, if the nodes in the given placements are not available. Value true means stick to explicitly given placements for fallback, else fail. Value false means fall back to entire cluster nodes when nodes in the given placements are unavailable. Default is false. It is ignored if topology-keys is not specified or load-balance is set to either prefer-primary or prefer-rr.
-* Failed Host Reconnect Delay Sec - When the driver cannot connect to a server, it marks it as failed with a timestamp. Later, whenever it refreshes the server list via yb_servers(), if it sees the failed server in the response, it marks the server as UP only if the time specified via this property has elapsed since the time it was last marked as a failed host. Default is 5 seconds.
-* Enable Discard Sequence - Flag to enable/disable running `Discard sequences` on connection Reset
-* Enable Discard Temp - Flag to enable/disable running `Discard Temp` on connection Reset
-* Enable Close All - Flag to enable/disable running `Close All` on connection Reset
-* Enable Discard Al - Flag to enable/disable running `Discard All` on connection Reset
-
-Pass new connection properties for load balancing in the connection string. To enable uniform load balancing across all servers, you set the `Load Balance Hosts` property to True in the URL, as per the following example.
-
-Connection String::
-
-```csharp
-var connString = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0";
-```
-
-#### Note: The behaviour of `Load Balance Hosts` is different in YugabyteDB Npgsql Driver as compared to the upstream driver. The upstream driver balances connections on the list of hosts provided in the `host` property while the YugabyteDB Npgsql Driver balances the connections on the list of servers returned by the `yb_servers()` function.
-
-To specify topology keys, you set the `Topology Keys` property to comma separated values, as per the following example.
-
-Connection String::
-
-```csharp
-var connString = "host=127.0.0.3;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0;Topology Keys=cloud.region.zone";
-```
-
-Multiple topologies can also be passed to the Topology Keys property, and each of them can also be given a preference value, as per the following example.
-
-```csharp
-var connString = "host=127.0.0.3;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0;Topology Keys=cloud1.region1.zone1:1,cloud2.region2.zone2:2";
-```

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -78,7 +78,12 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     /// <summary>
     /// Stores a map of host to their priority
     /// </summary>
-    protected static Dictionary<int, int> priorityToPoolIndexMap = new Dictionary<int, int>();
+    protected static Dictionary<int, List<int>> priorityToPoolIndexMapPrimary = new Dictionary<int, List<int>>();
+
+    /// <summary>
+    /// Stores a map of host to their priority
+    /// </summary>
+    protected static Dictionary<int, List<int>> priorityToPoolIndexMapRR = new Dictionary<int, List<int>>();
 
     /// <summary>
     /// Connection settings
@@ -129,6 +134,19 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     /// Value = Dictionary (IP , nodeType)
     /// </summary>
     protected ConcurrentDictionary<int, Dictionary<string, string>> fallbackPublicIPs;
+
+    /// <summary>
+    /// Contains a dictionary of IPs for all Read replica IPs
+    /// Key = Read replica IPs
+    /// Value = Dictionary (IP , nodeType)
+    /// </summary>
+    protected Dictionary<string, string> AllRRIps = new Dictionary<string, string>();
+    /// <summary>
+    /// Contains a dictionary of IPs for PRimary nodes of cluster
+    /// Key = Primary node IPs
+    /// Value = Dictionary (IP , nodeType)
+    /// </summary>
+    protected Dictionary<string, string> AllPrimaryIps = new Dictionary<string, string>();
 
     /// <summary>
     /// To set refresh value explicitly
@@ -343,7 +361,7 @@ public class ClusterAwareDataSource: NpgsqlDataSource
             if (poolToNumConnMapPrimary.ContainsKey(currPool))
             {
                 currentCount = poolToNumConnMapPrimary[currPool];
-                poolToNumConnMapPrimary[currPool] += incDec;
+                poolToNumConnMapPrimary[currPool] += incDec; 
                 _connectionLogger.LogTrace("Updated the current count for {host} from {currentCount} to {newCount}",
                     _pools[poolIndex].Settings.Host, currentCount, poolToNumConnMapPrimary[currPool]);
             }
@@ -406,7 +424,7 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     {
         NpgsqlConnector? connector = null;
         var exceptions = new List<Exception>();
-        connector = await getConnector(conn, timeout,async, cancellationToken, exceptions).ConfigureAwait(false);
+        connector = await getConnector(conn, timeout,async, cancellationToken, exceptions, false).ConfigureAwait(false);
 
         if (this is TopologyAwareDataSource)
         {
@@ -424,7 +442,7 @@ public class ClusterAwareDataSource: NpgsqlDataSource
                     {
                         exceptions.Clear();
                         CreatePool(fallbackPrivateIPs[i]);
-                        connector = await getConnector(conn, timeout,async, cancellationToken, exceptions).ConfigureAwait(false);
+                        connector = await getConnector(conn, timeout,async, cancellationToken, exceptions, false).ConfigureAwait(false);
                         if (connector != null)
                             break;
                     }
@@ -432,7 +450,7 @@ public class ClusterAwareDataSource: NpgsqlDataSource
                     {
                         exceptions.Clear();
                         CreatePool(fallbackPublicIPs[i]);
-                        connector = await getConnector(conn, timeout,async, cancellationToken, exceptions).ConfigureAwait(false);
+                        connector = await getConnector(conn, timeout,async, cancellationToken, exceptions, false).ConfigureAwait(false);
                         if (connector != null)
                             break;
                     }
@@ -449,14 +467,28 @@ public class ClusterAwareDataSource: NpgsqlDataSource
                 {
                     exceptions.Clear();
                     CreatePool(fallbackPrivateIPs[REST_OF_CLUSTER]);
-                    connector = await getConnector(conn, timeout,async, cancellationToken, exceptions).ConfigureAwait(false);
+                    connector = await getConnector(conn, timeout,async, cancellationToken, exceptions, false).ConfigureAwait(false);
                 }
                 else if (public_ip != null)
                 {
                     exceptions.Clear();
                     CreatePool(fallbackPublicIPs[REST_OF_CLUSTER]);
-                    connector = await getConnector(conn, timeout,async, cancellationToken, exceptions).ConfigureAwait(false);
+                    connector = await getConnector(conn, timeout,async, cancellationToken, exceptions, false).ConfigureAwait(false);
                 }
+            }
+        }
+
+        if (connector == null)
+        {
+            if (Settings.LoadBalanceHosts == LoadBalanceHosts.PreferPrimary)
+            {
+                CreatePool(AllRRIps);
+                connector = await getConnector(conn, timeout,async, cancellationToken, exceptions, true).ConfigureAwait(false);
+            }
+            if (Settings.LoadBalanceHosts == LoadBalanceHosts.PreferRR)
+            {
+                CreatePool(AllPrimaryIps);
+                connector = await getConnector(conn, timeout,async, cancellationToken, exceptions, true).ConfigureAwait(false);
             }
         }
 
@@ -466,7 +498,7 @@ public class ClusterAwareDataSource: NpgsqlDataSource
         }
         _connectionLogger.LogDebug("Failed to apply Load balance. Trying normal connection");
         conn.Settings.LoadBalanceHosts = LoadBalanceHosts.False;
-        connector = await getConnector(conn, timeout,async, cancellationToken, exceptions).ConfigureAwait(false);
+        connector = await getConnector(conn, timeout,async, cancellationToken, exceptions, true).ConfigureAwait(false);
         return connector ?? throw NoSuitableHostsException(exceptions);
     }
 
@@ -476,15 +508,36 @@ public class ClusterAwareDataSource: NpgsqlDataSource
         if (priority == chosenHostPriority)
             return null;
         NpgsqlConnector? connector = null;
-        var poolIndex = -1;
-        if (priorityToPoolIndexMap.ContainsKey(priority))
+        Dictionary<int, List<int>>? priorityToPoolIndexMap = null;
+        if (Settings.LoadBalanceHosts == LoadBalanceHosts.OnlyPrimary || Settings.LoadBalanceHosts == LoadBalanceHosts.PreferPrimary)
         {
-            poolIndex = priorityToPoolIndexMap[priority];
+            priorityToPoolIndexMap = priorityToPoolIndexMapPrimary;
+        }
+        else if (Settings.LoadBalanceHosts == LoadBalanceHosts.OnlyRR || Settings.LoadBalanceHosts == LoadBalanceHosts.PreferRR)
+        {
+            priorityToPoolIndexMap = priorityToPoolIndexMapRR;
+        }
+        else if (Settings.LoadBalanceHosts == LoadBalanceHosts.Any || Settings.LoadBalanceHosts == LoadBalanceHosts.True)
+        {
+            priorityToPoolIndexMap = priorityToPoolIndexMapPrimary
+                .Concat(priorityToPoolIndexMapRR)
+                .GroupBy(p => p.Key)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.SelectMany(x => x.Value).ToList()
+                );
+        }
+        Debug.Assert(priorityToPoolIndexMap != null, nameof(priorityToPoolIndexMap) + " = null");
+        if (!priorityToPoolIndexMap.TryGetValue(priority, out var poolIndices)){
+            priority++;
+            connector = await getConnector(chosenHostPriority, priority, conn, timeout, async, cancellationToken, exceptions)
+                .ConfigureAwait(false);
+            return connector;
         }
 
-        if (poolIndex == -1)
-            return null;
-        UpdateConnectionMap(poolIndex, 1);
+        foreach (var poolIndex in poolIndices)
+        {
+           UpdateConnectionMap(poolIndex, 1);
         var timeoutPerHost = timeout.IsSet ? timeout.CheckAndGetTimeLeft() : TimeSpan.Zero;
         var preferredType = GetTargetSessionAttributes(conn);
         var checkUnpreferred = preferredType is TargetSessionAttributes.PreferPrimary or TargetSessionAttributes.PreferStandby;
@@ -498,10 +551,16 @@ public class ClusterAwareDataSource: NpgsqlDataSource
                         : null);
         if (connector == null)
         {
+            unreachableHostsIndices.Add(poolIndex);
+            var settingsHost = _pools[poolIndex].Settings.Host;
+            if (settingsHost != null) unreachableHosts.Add(settingsHost);
+            var pool = _pools[poolIndex];
+            if (poolToNumConnMapPrimary.ContainsKey(pool))
+                poolToNumConnMapPrimary.Remove(pool);
+            else if (poolToNumConnMapRR.ContainsKey(pool))
+                poolToNumConnMapRR.Remove(pool);
             UpdateConnectionMap(poolIndex, -1);
-            priority++;
-            connector = await getConnector(chosenHostPriority, priority, conn, timeout, async, cancellationToken, exceptions)
-                .ConfigureAwait(false);
+            continue;
         }
 
         if (connector != null)
@@ -511,18 +570,28 @@ public class ClusterAwareDataSource: NpgsqlDataSource
             {
                 unreachableHosts.Remove(host);
             }
+
+            return connector;
         }
+        }
+
+        priority++;
+        connector = await getConnector(chosenHostPriority, priority, conn, timeout, async, cancellationToken, exceptions)
+            .ConfigureAwait(false);
         return connector;
     }
 
     async Task<NpgsqlConnector?> getConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async,
-        CancellationToken cancellationToken, List<Exception> exceptions)
+        CancellationToken cancellationToken, List<Exception> exceptions, bool isFinalFallback)
     {
         NpgsqlConnector? connector = null;
-        for (var i = 0; i < _pools.Count; i++)
+        while (true)
         {
             CheckDisposed();
-
+            if (AreAllEligiblePoolsExhausted() && !isFinalFallback)
+            {
+                return null;
+            }
             var poolIndex = conn.Settings.LoadBalanceHosts != LoadBalanceHosts.False ? GetRoundRobinIndex() : -2;
             if (poolIndex == -1)
                 return null;
@@ -718,6 +787,25 @@ public class ClusterAwareDataSource: NpgsqlDataSource
             return -1;
         }
     }
+
+    bool AreAllEligiblePoolsExhausted()
+    {
+        return settings.LoadBalanceHosts switch
+        {
+            LoadBalanceHosts.OnlyPrimary or LoadBalanceHosts.PreferPrimary=>
+                poolToNumConnMapPrimary.Count == 0,
+
+            LoadBalanceHosts.OnlyRR or LoadBalanceHosts.PreferRR =>
+                poolToNumConnMapRR.Count == 0,
+
+            LoadBalanceHosts.Any or LoadBalanceHosts.True =>
+                poolToNumConnMapPrimary.Count == 0 &&
+                poolToNumConnMapRR.Count == 0,
+
+            _ => true
+        };
+    }
+
 
     int getHosts(Dictionary<NpgsqlDataSource, int> poolToNumConnMap)
     {

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -71,6 +71,11 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     protected static Dictionary<NpgsqlDataSource, int> poolToNumConnMapRR = new Dictionary<NpgsqlDataSource, int>();
 
     /// <summary>
+    /// Preserves connection counts across map rebuilds (e.g. during Refresh).
+    /// </summary>
+    protected static Dictionary<string, int> _savedConnectionCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Stores a map of host to their priority
     /// </summary>
     protected static Dictionary<string, int> hostToPriorityMap = new Dictionary<string, int>();
@@ -286,6 +291,11 @@ public class ClusterAwareDataSource: NpgsqlDataSource
             }
         }
 
+        if (_savedConnectionCounts.TryGetValue(server, out var savedCount) && savedCount > 0)
+        {
+            return savedCount;
+        }
+
         return 0;
     }
 
@@ -357,20 +367,43 @@ public class ClusterAwareDataSource: NpgsqlDataSource
         lock (lockObject)
         {
             int currentCount;
+            var host = _pools[poolIndex].Settings.Host;
 
             if (poolToNumConnMapPrimary.ContainsKey(currPool))
             {
                 currentCount = poolToNumConnMapPrimary[currPool];
                 poolToNumConnMapPrimary[currPool] += incDec; 
                 _connectionLogger.LogTrace("Updated the current count for {host} from {currentCount} to {newCount}",
-                    _pools[poolIndex].Settings.Host, currentCount, poolToNumConnMapPrimary[currPool]);
+                    host, currentCount, poolToNumConnMapPrimary[currPool]);
             }
             else if (poolToNumConnMapRR.ContainsKey(currPool))
             {
                 currentCount = poolToNumConnMapRR[currPool];
                 poolToNumConnMapRR[currPool] += incDec;
                 _connectionLogger.LogTrace("Updated the current count for {host} from {currentCount} to {newCount}",
-                    _pools[poolIndex].Settings.Host, currentCount, poolToNumConnMapRR[currPool]);
+                    host, currentCount, poolToNumConnMapRR[currPool]);
+            }
+            else if (incDec > 0)
+            {
+                if (_hostsToNodeTypeMap != null && host != null && _hostsToNodeTypeMap.TryGetValue(host, out var nodeType))
+                {
+                    if (nodeType.Equals("read_replica", StringComparison.OrdinalIgnoreCase))
+                    {
+                        poolToNumConnMapRR[currPool] = Math.Max(0, incDec);
+                    }
+                    else
+                    {
+                        poolToNumConnMapPrimary[currPool] = Math.Max(0, incDec);
+                    }
+                }
+            }
+            else if (incDec < 0 && host != null && _savedConnectionCounts.TryGetValue(host, out var savedCount))
+            {
+                var newCount = savedCount + incDec;
+                if (newCount > 0)
+                    _savedConnectionCounts[host] = newCount;
+                else
+                    _savedConnectionCounts.Remove(host);
             }
         }
     }
@@ -551,9 +584,9 @@ public class ClusterAwareDataSource: NpgsqlDataSource
                         : null);
         if (connector == null)
         {
-            unreachableHostsIndices.Add(poolIndex);
+            if (!unreachableHostsIndices.Contains(poolIndex)) unreachableHostsIndices.Add(poolIndex);
             var settingsHost = _pools[poolIndex].Settings.Host;
-            if (settingsHost != null) unreachableHosts.Add(settingsHost);
+            if (settingsHost != null && !unreachableHosts.Contains(settingsHost)) unreachableHosts.Add(settingsHost);
             var pool = _pools[poolIndex];
             if (poolToNumConnMapPrimary.ContainsKey(pool))
                 poolToNumConnMapPrimary.Remove(pool);
@@ -637,10 +670,9 @@ public class ClusterAwareDataSource: NpgsqlDataSource
             {
                 break;
             }
-            unreachableHostsIndices.Add(poolIndex);
+            if (!unreachableHostsIndices.Contains(poolIndex)) unreachableHostsIndices.Add(poolIndex);
             var settingsHost = _pools[poolIndex].Settings.Host;
-            if (settingsHost != null) unreachableHosts.Add(settingsHost);
-            // poolToNumConnMap.Remove(poolIndex);
+            if (settingsHost != null && !unreachableHosts.Contains(settingsHost)) unreachableHosts.Add(settingsHost);
             var pool = _pools[poolIndex];
             if (poolToNumConnMapPrimary.ContainsKey(pool))
                 poolToNumConnMapPrimary.Remove(pool);

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -610,8 +610,6 @@ public class ClusterAwareDataSource: NpgsqlDataSource
             }
         }
         UpdateConnectionMap(poolIndex, -1);
-        // Return the connector back to the pool to avoid memory leak
-        _pools[poolIndex].Return(connector);
     }
 
     /// <inheritdoc />

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -589,6 +589,8 @@ public class ClusterAwareDataSource: NpgsqlDataSource
     internal override bool TryGetIdleConnector([NotNullWhen(true)] out NpgsqlConnector? connector)
         => throw new NpgsqlException("Npgsql bug: trying to get an idle connector from " + nameof(ClusterAwareDataSource));
 
+    internal override bool TryGetIdleConnector(NpgsqlConnectionStringBuilder originalConnString, out NpgsqlConnector? connector) => throw new NotImplementedException();
+
     internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken) => throw new NotImplementedException();
 
     internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken,
@@ -776,16 +778,20 @@ public class ClusterAwareDataSource: NpgsqlDataSource
         NpgsqlConnector? connector = null;
         try
         {
-            if (pool.TryGetIdleConnector(out connector))
+            if (pool.TryGetIdleConnector(settings, out connector))
             {
                 if (databaseState == DatabaseState.Unknown)
                 {
-                    databaseState = await connector.QueryDatabaseState(new NpgsqlTimeout(timeoutPerHost), async, cancellationToken).ConfigureAwait(false);
-                    Debug.Assert(databaseState != DatabaseState.Unknown);
-                    if (!stateValidator(databaseState, preferredType))
+                    if (connector != null)
                     {
-                        pool.Return(connector);
-                        return null;
+                        databaseState = await connector.QueryDatabaseState(new NpgsqlTimeout(timeoutPerHost), async, cancellationToken)
+                            .ConfigureAwait(false);
+                        Debug.Assert(databaseState != DatabaseState.Unknown);
+                        if (!stateValidator(databaseState, preferredType))
+                        {
+                            pool.Return(connector);
+                            return null;
+                        }
                     }
                 }
                 return connector;

--- a/src/Npgsql/ClusterAwareDataSource.cs
+++ b/src/Npgsql/ClusterAwareDataSource.cs
@@ -223,7 +223,7 @@ public class ClusterAwareDataSource: NpgsqlDataSource
                 var poolSettings = settings.Clone();
                 poolSettings.Host = host.Key;
                 _connectionLogger.LogDebug("Adding {host} to connection pool", poolSettings.Host);
-                NpgsqlDataSource poolnew = settings.Pooling? new PoolingDataSource(poolSettings, dataSourceConfig): new UnpooledDataSource(poolSettings, dataSourceConfig);
+                NpgsqlDataSource poolnew = settings.Pooling? new YBPoolingWrapperDataSource(poolSettings, dataSourceConfig): new UnpooledDataSource(poolSettings, dataSourceConfig);
                 _pools.Add(poolnew);
                 if (host.Value.Equals("primary", StringComparison.OrdinalIgnoreCase))
                 {
@@ -591,6 +591,10 @@ public class ClusterAwareDataSource: NpgsqlDataSource
 
     internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken) => throw new NotImplementedException();
 
+    internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken,
+        NpgsqlConnectionStringBuilder settings) =>
+        throw new NotImplementedException();
+
     internal override void Return(NpgsqlConnector connector)
     {
         var host = connector.Host;
@@ -604,6 +608,8 @@ public class ClusterAwareDataSource: NpgsqlDataSource
             }
         }
         UpdateConnectionMap(poolIndex, -1);
+        // Return the connector back to the pool to avoid memory leak
+        _pools[poolIndex].Return(connector);
     }
 
     /// <inheritdoc />
@@ -786,7 +792,7 @@ public class ClusterAwareDataSource: NpgsqlDataSource
             }
             else
             {
-                connector = await pool.OpenNewConnector(conn, new NpgsqlTimeout(timeoutPerHost), async, cancellationToken).ConfigureAwait(false);
+                connector = await pool.OpenNewConnector(conn, new NpgsqlTimeout(timeoutPerHost), async, cancellationToken, settings).ConfigureAwait(false);
                 if (connector is not null)
                 {
                     if (databaseState == DatabaseState.Unknown)

--- a/src/Npgsql/MultiHostDataSourceWrapper.cs
+++ b/src/Npgsql/MultiHostDataSourceWrapper.cs
@@ -36,6 +36,9 @@ sealed class MultiHostDataSourceWrapper(NpgsqlMultiHostDataSource wrappedSource,
         => wrappedSource.Get(conn, timeout, async, cancellationToken);
     internal override bool TryGetIdleConnector([NotNullWhen(true)] out NpgsqlConnector? connector)
         => throw new NpgsqlException("Npgsql bug: trying to get an idle connector from " + nameof(MultiHostDataSourceWrapper));
+
+    internal override bool TryGetIdleConnector(NpgsqlConnectionStringBuilder originalConnString, out NpgsqlConnector? connector) => throw new System.NotImplementedException();
+
     internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         => throw new NpgsqlException("Npgsql bug: trying to open a new connector from " + nameof(MultiHostDataSourceWrapper));
 

--- a/src/Npgsql/MultiHostDataSourceWrapper.cs
+++ b/src/Npgsql/MultiHostDataSourceWrapper.cs
@@ -38,6 +38,11 @@ sealed class MultiHostDataSourceWrapper(NpgsqlMultiHostDataSource wrappedSource,
         => throw new NpgsqlException("Npgsql bug: trying to get an idle connector from " + nameof(MultiHostDataSourceWrapper));
     internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         => throw new NpgsqlException("Npgsql bug: trying to open a new connector from " + nameof(MultiHostDataSourceWrapper));
+
+    internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken,
+        NpgsqlConnectionStringBuilder settings) =>
+        throw new System.NotImplementedException();
+
     internal override void Return(NpgsqlConnector connector)
         => wrappedSource.Return(connector);
 

--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -399,6 +399,9 @@ public abstract class NpgsqlDataSource : DbDataSource
 
     internal abstract bool TryGetIdleConnector([NotNullWhen(true)] out NpgsqlConnector? connector);
 
+    internal abstract bool TryGetIdleConnector(NpgsqlConnectionStringBuilder originalConnString, out NpgsqlConnector? connector);
+
+
     internal abstract ValueTask<NpgsqlConnector?> OpenNewConnector(
         NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken);
 
@@ -559,4 +562,5 @@ public abstract class NpgsqlDataSource : DbDataSource
 
         public DatabaseStateInfo() : this(default, default, default) { }
     }
+
 }

--- a/src/Npgsql/NpgsqlDataSource.cs
+++ b/src/Npgsql/NpgsqlDataSource.cs
@@ -25,7 +25,7 @@ public abstract class NpgsqlDataSource : DbDataSource
     /// Contains the connection string returned to the user from <see cref="NpgsqlConnection.ConnectionString"/>
     /// after the connection has been opened. Does not contain the password unless Persist Security Info=true.
     /// </summary>
-    internal NpgsqlConnectionStringBuilder Settings { get; }
+    internal NpgsqlConnectionStringBuilder Settings { get; set; }
 
     internal NpgsqlDataSourceConfiguration Configuration { get; }
     internal NpgsqlLoggingConfiguration LoggingConfiguration { get; }
@@ -401,6 +401,9 @@ public abstract class NpgsqlDataSource : DbDataSource
 
     internal abstract ValueTask<NpgsqlConnector?> OpenNewConnector(
         NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken);
+
+    internal abstract ValueTask<NpgsqlConnector?> OpenNewConnector(
+        NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken, NpgsqlConnectionStringBuilder settings);
 
     internal abstract void Return(NpgsqlConnector connector);
 

--- a/src/Npgsql/NpgsqlMultiHostDataSource.cs
+++ b/src/Npgsql/NpgsqlMultiHostDataSource.cs
@@ -370,6 +370,8 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
     internal override bool TryGetIdleConnector([NotNullWhen(true)] out NpgsqlConnector? connector)
         => throw new NpgsqlException("Npgsql bug: trying to get an idle connector from " + nameof(NpgsqlMultiHostDataSource));
 
+    internal override bool TryGetIdleConnector(NpgsqlConnectionStringBuilder originalConnString, out NpgsqlConnector? connector) => throw new NotImplementedException();
+
     internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         => throw new NpgsqlException("Npgsql bug: trying to open a new connector from " + nameof(NpgsqlMultiHostDataSource));
 

--- a/src/Npgsql/NpgsqlMultiHostDataSource.cs
+++ b/src/Npgsql/NpgsqlMultiHostDataSource.cs
@@ -360,6 +360,10 @@ public sealed class NpgsqlMultiHostDataSource : NpgsqlDataSource
         }
     }
 
+    internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken,
+        NpgsqlConnectionStringBuilder settings) =>
+        throw new NotImplementedException();
+
     internal override void Return(NpgsqlConnector connector)
         => throw new NpgsqlException("Npgsql bug: a connector was returned to " + nameof(NpgsqlMultiHostDataSource));
 

--- a/src/Npgsql/PoolingDataSource.cs
+++ b/src/Npgsql/PoolingDataSource.cs
@@ -320,6 +320,10 @@ class PoolingDataSource : NpgsqlDataSource
         return null;
     }
 
+    internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken,
+        NpgsqlConnectionStringBuilder settings) =>
+        throw new NotImplementedException();
+
     internal sealed override void Return(NpgsqlConnector connector)
     {
         Debug.Assert(!connector.InTransaction);

--- a/src/Npgsql/PoolingDataSource.cs
+++ b/src/Npgsql/PoolingDataSource.cs
@@ -218,8 +218,10 @@ class PoolingDataSource : NpgsqlDataSource
         return false;
     }
 
+    internal override bool TryGetIdleConnector(NpgsqlConnectionStringBuilder originalConnString, out NpgsqlConnector? connector) => throw new NotImplementedException();
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    bool CheckIdleConnector([NotNullWhen(true)] NpgsqlConnector? connector)
+    protected bool CheckIdleConnector([NotNullWhen(true)] NpgsqlConnector? connector)
     {
         if (connector is null)
             return false;
@@ -324,7 +326,7 @@ class PoolingDataSource : NpgsqlDataSource
         NpgsqlConnectionStringBuilder settings) =>
         throw new NotImplementedException();
 
-    internal sealed override void Return(NpgsqlConnector connector)
+    internal override void Return(NpgsqlConnector connector)
     {
         Debug.Assert(!connector.InTransaction);
         Debug.Assert(connector.MultiplexAsyncWritingLock == 0 || connector.IsBroken || connector.IsClosed,
@@ -370,7 +372,7 @@ class PoolingDataSource : NpgsqlDataSource
         }
     }
 
-    void CloseConnector(NpgsqlConnector connector)
+    protected void CloseConnector(NpgsqlConnector connector)
     {
         try
         {

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -76,4 +76,3 @@ YBNpgsql.NpgsqlConnection.ReloadTypesAsync(System.Threading.CancellationToken ca
 *REMOVED*YBNpgsql.NpgsqlSlimDataSourceBuilder.MapComposite<T>(string? pgName = null, YBNpgsql.INpgsqlNameTranslator? nameTranslator = null) -> YBNpgsql.TypeMapping.INpgsqlTypeMapper!
 *REMOVED*YBNpgsql.NpgsqlSlimDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, YBNpgsql.INpgsqlNameTranslator? nameTranslator = null) -> YBNpgsql.TypeMapping.INpgsqlTypeMapper!
 *REMOVED*YBNpgsql.NpgsqlSlimDataSourceBuilder.MapEnum<TEnum>(string? pgName = null, YBNpgsql.INpgsqlNameTranslator? nameTranslator = null) -> YBNpgsql.TypeMapping.INpgsqlTypeMapper!
-

--- a/src/Npgsql/PublicAPI.Unshipped.txt
+++ b/src/Npgsql/PublicAPI.Unshipped.txt
@@ -76,3 +76,4 @@ YBNpgsql.NpgsqlConnection.ReloadTypesAsync(System.Threading.CancellationToken ca
 *REMOVED*YBNpgsql.NpgsqlSlimDataSourceBuilder.MapComposite<T>(string? pgName = null, YBNpgsql.INpgsqlNameTranslator? nameTranslator = null) -> YBNpgsql.TypeMapping.INpgsqlTypeMapper!
 *REMOVED*YBNpgsql.NpgsqlSlimDataSourceBuilder.MapEnum(System.Type! clrType, string? pgName = null, YBNpgsql.INpgsqlNameTranslator? nameTranslator = null) -> YBNpgsql.TypeMapping.INpgsqlTypeMapper!
 *REMOVED*YBNpgsql.NpgsqlSlimDataSourceBuilder.MapEnum<TEnum>(string? pgName = null, YBNpgsql.INpgsqlNameTranslator? nameTranslator = null) -> YBNpgsql.TypeMapping.INpgsqlTypeMapper!
+

--- a/src/Npgsql/TopologyAwareDataSource.cs
+++ b/src/Npgsql/TopologyAwareDataSource.cs
@@ -142,7 +142,28 @@ public sealed class TopologyAwareDataSource: ClusterAwareDataSource
                 }
 
                 if (flag == 1)
+                {
+                    var existingPool = _pools.First(p => host.Key.Equals(p.Settings.Host, StringComparison.OrdinalIgnoreCase));
+                    if (host.Value.Equals("primary", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!poolToNumConnMapPrimary.ContainsKey(existingPool))
+                        {
+                            var restoredCount = _savedConnectionCounts.TryGetValue(host.Key, out var sc) ? sc : 0;
+                            poolToNumConnMapPrimary[existingPool] = restoredCount;
+                            _savedConnectionCounts.Remove(host.Key);
+                        }
+                    }
+                    else if (host.Value.Equals("read_replica", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!poolToNumConnMapRR.ContainsKey(existingPool))
+                        {
+                            var restoredCount = _savedConnectionCounts.TryGetValue(host.Key, out var sc) ? sc : 0;
+                            poolToNumConnMapRR[existingPool] = restoredCount;
+                            _savedConnectionCounts.Remove(host.Key);
+                        }
+                    }
                     continue;
+                }
                 var poolSettings = settings.Clone();
                 poolSettings.Host = host.Key;
                 _connectionLogger.LogDebug("Adding {host} to connection pool", poolSettings.Host);
@@ -291,7 +312,6 @@ public sealed class TopologyAwareDataSource: ClusterAwareDataSource
                 }
             }
         }
-        
         return serversNodeTypeMapCopy;
     }
     new Dictionary<string, string> GetPrivateOrPublicServers(Dictionary<string, string> privateHosts, Dictionary<string,string> publicHosts)
@@ -353,7 +373,6 @@ public sealed class TopologyAwareDataSource: ClusterAwareDataSource
 
         if (serverToNodeTypeMap.Any())
             return serverToNodeTypeMap;
-
         if (settings.LoadBalanceHosts == LoadBalanceHosts.PreferPrimary)
         {
             return AllRRIps;
@@ -424,6 +443,12 @@ public sealed class TopologyAwareDataSource: ClusterAwareDataSource
     internal override bool Refresh()
     {
         _connectionLogger.LogDebug("Refreshing connection");
+        foreach (var kvp in poolToNumConnMapPrimary)
+            if (kvp.Key.Settings.Host != null)
+                _savedConnectionCounts[kvp.Key.Settings.Host] = kvp.Value;
+        foreach (var kvp in poolToNumConnMapRR)
+            if (kvp.Key.Settings.Host != null)
+                _savedConnectionCounts[kvp.Key.Settings.Host] = kvp.Value;
         poolToNumConnMapPrimary.Clear();
         poolToNumConnMapRR.Clear();
         Debug.Assert(initialHosts != null, nameof(initialHosts) + " != null");

--- a/src/Npgsql/TopologyAwareDataSource.cs
+++ b/src/Npgsql/TopologyAwareDataSource.cs
@@ -148,7 +148,7 @@ public sealed class TopologyAwareDataSource: ClusterAwareDataSource
                 var poolSettings = settings.Clone();
                 poolSettings.Host = host.Key;
                 _connectionLogger.LogDebug("Adding {host} to connection pool", poolSettings.Host);
-                NpgsqlDataSource poolnew = settings.Pooling? new PoolingDataSource(poolSettings, dataSourceConfig): new UnpooledDataSource(poolSettings, dataSourceConfig);
+                NpgsqlDataSource poolnew = settings.Pooling? new YBPoolingWrapperDataSource(poolSettings, dataSourceConfig): new UnpooledDataSource(poolSettings, dataSourceConfig);
                 _pools.Add(poolnew);
                 int index;
                 index = _pools.IndexOf(poolnew);

--- a/src/Npgsql/TopologyAwareDataSource.cs
+++ b/src/Npgsql/TopologyAwareDataSource.cs
@@ -16,13 +16,11 @@ namespace YBNpgsql;
 public sealed class TopologyAwareDataSource: ClusterAwareDataSource
 {
     ConcurrentDictionary<int, HashSet<CloudPlacement>?> allowedPlacements;
-    Dictionary<string, string> AllRRIps = new Dictionary<string, string>();
-    Dictionary<string, string> AllPrimaryIps = new Dictionary<string, string>();
 
     internal TopologyAwareDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfig) : base(settings,dataSourceConfig,false)
     {
         allowedPlacements = new ConcurrentDictionary<int, HashSet<CloudPlacement>?>();
-        ParseGeoLocations();
+        ParseGeoLocations(); 
         _connectionLogger.LogDebug("Allowed Placements: {allowedPlacements}", allowedPlacements);
         Debug.Assert(initialHosts != null, nameof(initialHosts) + " != null");
         foreach (var host in initialHosts.ToList())
@@ -153,13 +151,26 @@ public sealed class TopologyAwareDataSource: ClusterAwareDataSource
                 int index;
                 index = _pools.IndexOf(poolnew);
                 var priority = hostToPriorityMap[host.Key];
-                priorityToPoolIndexMap[priority] = index;
                 if (host.Value.Equals("primary", StringComparison.OrdinalIgnoreCase))
                 {
+                    if (!priorityToPoolIndexMapPrimary.TryGetValue(priority, out var list))
+                    {
+                        list = new List<int>();
+                        priorityToPoolIndexMapPrimary[priority] = list;
+                    }
+
+                    list.Add(index);;
                     poolToNumConnMapPrimary[poolnew] = 0;
                 }
                 else if (host.Value.Equals("read_replica", StringComparison.OrdinalIgnoreCase))
                 {
+                    if (!priorityToPoolIndexMapRR.TryGetValue(priority, out var list))
+                    {
+                        list = new List<int>();
+                        priorityToPoolIndexMapRR[priority] = list;
+                    }
+
+                    list.Add(index);
                     poolToNumConnMapRR[poolnew] = 0;
                 }
             }
@@ -280,7 +291,7 @@ public sealed class TopologyAwareDataSource: ClusterAwareDataSource
                 }
             }
         }
-
+        
         return serversNodeTypeMapCopy;
     }
     new Dictionary<string, string> GetPrivateOrPublicServers(Dictionary<string, string> privateHosts, Dictionary<string,string> publicHosts)
@@ -329,7 +340,6 @@ public sealed class TopologyAwareDataSource: ClusterAwareDataSource
                 return AllPrimaryIps;
             }
         }
-
         fallbackPrivateIPs.TryGetValue(REST_OF_CLUSTER, out var privateIPRest);
         fallbackPublicIPs.TryGetValue(REST_OF_CLUSTER, out var publicIPRest);
 

--- a/src/Npgsql/UnpooledDataSource.cs
+++ b/src/Npgsql/UnpooledDataSource.cs
@@ -43,6 +43,10 @@ sealed class UnpooledDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDa
         NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         => new((NpgsqlConnector?)null);
 
+    internal override ValueTask<NpgsqlConnector?> OpenNewConnector(NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken,
+        NpgsqlConnectionStringBuilder settings) =>
+        throw new System.NotImplementedException();
+
     internal override void Return(NpgsqlConnector connector)
     {
         Interlocked.Decrement(ref _numConnectors);

--- a/src/Npgsql/UnpooledDataSource.cs
+++ b/src/Npgsql/UnpooledDataSource.cs
@@ -39,6 +39,8 @@ sealed class UnpooledDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDa
         return false;
     }
 
+    internal override bool TryGetIdleConnector(NpgsqlConnectionStringBuilder originalConnString, out NpgsqlConnector? connector) => throw new System.NotImplementedException();
+
     internal override ValueTask<NpgsqlConnector?> OpenNewConnector(
         NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken)
         => new((NpgsqlConnector?)null);

--- a/src/Npgsql/YBPoolingWrapperDataSource.cs
+++ b/src/Npgsql/YBPoolingWrapperDataSource.cs
@@ -12,6 +12,7 @@ namespace YBNpgsql;
 /// </summary>
 sealed class YBPoolingWrapperDataSource: PoolingDataSource
 {
+    static readonly object lockObject = new object();
     ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToConnectorsMap = null!;
     ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToIdleConnectorsMap = null!;
 
@@ -43,7 +44,7 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
 
         if (connector is not null)
         {
-            lock (connStringToConnectorsMap)
+            lock (lockObject)
             {
                 if (connStringToConnectorsMap.TryGetValue(originalConnString, out var list))
                 {
@@ -78,27 +79,30 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
 
         // Fast scan for the first non-null, *idle* connector
         // (assuming "idle" means connector.State == Idle or similar)
-        for (var i = 0; i < connectors.Length; i++)
+        lock (lockObject)
         {
-            var c = connectors[i];
-            if (c is null)
-                continue;  // skip nulls quickly
-
-            if (CheckIdleConnector(c))
+            for (var i = 0; i < connectors.Length; i++)
             {
-                connector = c;
-                for (var j = 0; j < MaxConnections; j++)
-                    if (Interlocked.CompareExchange(ref connectors[j], null, connector) == connector)
-                        break;
-                connStringToIdleConnectorsMap[originalConnString] = connectors;
-                if (connStringToConnectorsMap.TryGetValue(originalConnString, out  var list))
+                var c = connectors[i];
+                if (c is null)
+                    continue;  // skip nulls quickly
+
+                if (CheckIdleConnector(c))
                 {
-                    for (var j = 0; i < MaxConnections; i++)
-                        if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
+                    connector = c;
+                    for (var j = 0; j < MaxConnections; j++)
+                        if (Interlocked.CompareExchange(ref connectors[j], null, connector) == connector)
                             break;
-                    connStringToConnectorsMap[originalConnString] = list;
+                    connStringToIdleConnectorsMap[originalConnString] = connectors;
+                    if (connStringToConnectorsMap.TryGetValue(originalConnString, out  var list))
+                    {
+                        for (var j = 0; i < MaxConnections; i++)
+                            if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
+                                break;
+                        connStringToConnectorsMap[originalConnString] = list;
+                    }
+                    return true;
                 }
-                return true;
             }
         }
 
@@ -108,46 +112,50 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
     internal override void Return(NpgsqlConnector connector)
     {
         var flag = 0;
-        foreach (var connStringToConnectors in connStringToConnectorsMap)
+        lock (lockObject)
         {
-            for (var i = 0; i < connStringToConnectors.Value.Length; i++)
+            foreach (var connStringToConnectors in connStringToConnectorsMap)
             {
-                if (connStringToConnectors.Value[i] == null)
-                    continue;
-                if (ReferenceEquals(connStringToConnectors.Value[i], connector))
+                for (var i = 0; i < connStringToConnectors.Value.Length; i++)
                 {
-
-                    if (connStringToConnectorsMap.TryGetValue(connStringToConnectors.Key, out var connectorslist))
+                    if (connStringToConnectors.Value[i] == null)
+                        continue;
+                    if (ReferenceEquals(connStringToConnectors.Value[i], connector))
                     {
-                        for (var j = 0; j < MaxConnections; j++)
-                            if (Interlocked.CompareExchange(ref connectorslist[j], null, connector) == connector)
-                                break;
-                        connStringToConnectorsMap[connStringToConnectors.Key] = connectorslist;
 
-                    }
-                    if (connStringToIdleConnectorsMap.TryGetValue(connStringToConnectors.Key, out  var list))
-                    {
-                        for (var j = 0; i < MaxConnections; i++)
-                            if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
-                                break;
-                        connStringToIdleConnectorsMap[connStringToConnectors.Key] = list;
-                    }
-                    else
-                    {
-                        list = new NpgsqlConnector[MaxConnections];
-                        for (var j = 0; i < MaxConnections; i++)
-                            if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
-                                break;
-                        connStringToIdleConnectorsMap[connStringToConnectors.Key] = list;
-                    }
+                        if (connStringToConnectorsMap.TryGetValue(connStringToConnectors.Key, out var connectorslist))
+                        {
+                            for (var j = 0; j < MaxConnections; j++)
+                                if (Interlocked.CompareExchange(ref connectorslist[j], null, connector) == connector)
+                                    break;
+                            connStringToConnectorsMap[connStringToConnectors.Key] = connectorslist;
 
-                    flag = 1;
-                    break;
+                        }
+                        if (connStringToIdleConnectorsMap.TryGetValue(connStringToConnectors.Key, out  var list))
+                        {
+                            for (var j = 0; i < MaxConnections; i++)
+                                if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
+                                    break;
+                            connStringToIdleConnectorsMap[connStringToConnectors.Key] = list;
+                        }
+                        else
+                        {
+                            list = new NpgsqlConnector[MaxConnections];
+                            for (var j = 0; i < MaxConnections; i++)
+                                if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
+                                    break;
+                            connStringToIdleConnectorsMap[connStringToConnectors.Key] = list;
+                        }
+
+                        flag = 1;
+                        break;
+                    }
                 }
+                if (flag == 1)
+                    break;
             }
-            if (flag == 1)
-                break;
         }
+
         base.Return(connector);
 
     }

--- a/src/Npgsql/YBPoolingWrapperDataSource.cs
+++ b/src/Npgsql/YBPoolingWrapperDataSource.cs
@@ -1,7 +1,5 @@
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using YBNpgsql.Internal;
@@ -15,10 +13,14 @@ namespace YBNpgsql;
 sealed class YBPoolingWrapperDataSource: PoolingDataSource
 {
     static ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToConnectorsMap = null!;
+    static ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToIdleConnectorsMap = null!;
+
     internal YBPoolingWrapperDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfiguration) :
         base(settings, dataSourceConfiguration)
     {
         connStringToConnectorsMap = new ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>();
+        connStringToIdleConnectorsMap = new ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>();
+
     }
 
     internal override async ValueTask<NpgsqlConnector?> OpenNewConnector(
@@ -65,15 +67,93 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
         return connector;
     }
 
-    internal new bool TryGetIdleConnector([NotNullWhen(true)] out NpgsqlConnector? connector)
+    internal override bool TryGetIdleConnector(NpgsqlConnectionStringBuilder originalConnString, [NotNullWhen(true)] out NpgsqlConnector? connector)
 
     {
-        return base.TryGetIdleConnector(out connector);
+        connector = null;
+
+        // Try to get the array for this conn string
+        if (!connStringToConnectorsMap.TryGetValue(originalConnString, out var connectors))
+            return false;
+
+        // Fast scan for the first non-null, *idle* connector
+        // (assuming "idle" means connector.State == Idle or similar)
+        for (var i = 0; i < connectors.Length; i++)
+        {
+            var c = connectors[i];
+            if (c is null)
+                continue;  // skip nulls quickly
+
+            if (CheckIdleConnector(c))
+            {
+                connector = c;
+                if (connStringToIdleConnectorsMap.TryGetValue(originalConnString, out var idleconnectorslist))
+                {
+                    for (var j = 0; j < MaxConnections; j++)
+                        if (Interlocked.CompareExchange(ref idleconnectorslist[j], null, connector) == connector)
+                            break;
+                    connStringToIdleConnectorsMap[originalConnString] = idleconnectorslist;
+
+                }
+                if (connStringToConnectorsMap.TryGetValue(originalConnString, out  var list))
+                {
+                    for (var j = 0; i < MaxConnections; i++)
+                        if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
+                            break;
+                    connStringToConnectorsMap[originalConnString] = list;
+                }
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    internal new void Return(NpgsqlConnector connector)
+    internal override void Return(NpgsqlConnector connector)
     {
-       base.Return(connector);
+        var flag = 0;
+        foreach (var connStringToConnectors in connStringToConnectorsMap)
+        {
+            for (var i = 0; i < connStringToConnectors.Value.Length; i++)
+            {
+                if (connStringToConnectors.Value[i] == null)
+                    continue;
+                if (ReferenceEquals(connStringToConnectors.Value[i], connector))
+                {
+
+                    if (connStringToConnectorsMap.TryGetValue(connStringToConnectors.Key, out var connectorslist))
+                    {
+                        for (var j = 0; j < MaxConnections; j++)
+                            if (Interlocked.CompareExchange(ref connectorslist[j], null, connector) == connector)
+                                break;
+                        connStringToConnectorsMap[connStringToConnectors.Key] = connectorslist;
+
+                    }
+                    if (connStringToIdleConnectorsMap.TryGetValue(connStringToConnectors.Key, out  var list))
+                    {
+                        for (var j = 0; i < MaxConnections; i++)
+                            if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
+                                break;
+                        connStringToIdleConnectorsMap[connStringToConnectors.Key] = list;
+                    }
+                    else
+                    {
+                        list = new NpgsqlConnector[MaxConnections];
+                        for (var j = 0; i < MaxConnections; i++)
+                            if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
+                                break;
+                        connStringToIdleConnectorsMap[connStringToConnectors.Key] = list;
+                    }
+
+                    flag = 1;
+                    break;
+                }
+            }
+            if (flag == 1)
+                break;
+        }
+        base.Return(connector);
+
     }
 
 

--- a/src/Npgsql/YBPoolingWrapperDataSource.cs
+++ b/src/Npgsql/YBPoolingWrapperDataSource.cs
@@ -1,0 +1,80 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using YBNpgsql.Internal;
+using YBNpgsql.Util;
+
+namespace YBNpgsql;
+
+/// <summary>
+///
+/// </summary>
+sealed class YBPoolingWrapperDataSource: PoolingDataSource
+{
+    static ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToConnectorsMap = null!;
+    internal YBPoolingWrapperDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfiguration) :
+        base(settings, dataSourceConfiguration)
+    {
+        connStringToConnectorsMap = new ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>();
+    }
+
+    internal override async ValueTask<NpgsqlConnector?> OpenNewConnector(
+        NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken, NpgsqlConnectionStringBuilder originalConnString)
+    {
+        var originalConnStringCopy = originalConnString.Clone();
+        /*
+         * The connectors are created using the Settings initialized in the pool.
+         * When connection strings are different, it will still use the first connection string which was initialized in the pool to create the connection.
+         * So check if connection string is same as the original connection string
+         * if not replace the host in the original conn string with the chosen host in the pool Settings
+         */
+        if (!Settings.Equals(originalConnStringCopy))
+        {
+            originalConnStringCopy.Host = Settings.Host;
+            Settings = originalConnStringCopy;
+        }
+        // 1. Call base logic → this increments _numConnectors and populates Connectors[]
+        var connector = await base.OpenNewConnector(conn, timeout, async, cancellationToken).ConfigureAwait(false);
+
+        if (connector is not null)
+        {
+            lock (connStringToConnectorsMap)
+            {
+                if (connStringToConnectorsMap.TryGetValue(originalConnString, out var list))
+                {
+                    for (var i = 0; i < MaxConnections; i++)
+                        if (Interlocked.CompareExchange(ref list[i], connector, null) == null)
+                            break;
+                    connStringToConnectorsMap[originalConnString] = list;
+                }
+                else
+                {
+                    list = new NpgsqlConnector[MaxConnections];
+                    for (var i = 0; i < MaxConnections; i++)
+                        if (Interlocked.CompareExchange(ref list[i], connector, null) == null)
+                            break;
+                    connStringToConnectorsMap[originalConnString] = list;
+                }
+            }
+
+        }
+
+        return connector;
+    }
+
+    internal new bool TryGetIdleConnector([NotNullWhen(true)] out NpgsqlConnector? connector)
+
+    {
+        return base.TryGetIdleConnector(out connector);
+    }
+
+    internal new void Return(NpgsqlConnector connector)
+    {
+       base.Return(connector);
+    }
+
+
+}

--- a/src/Npgsql/YBPoolingWrapperDataSource.cs
+++ b/src/Npgsql/YBPoolingWrapperDataSource.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using YBNpgsql.Internal;
@@ -27,20 +28,27 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
     internal override async ValueTask<NpgsqlConnector?> OpenNewConnector(
         NpgsqlConnection conn, NpgsqlTimeout timeout, bool async, CancellationToken cancellationToken, NpgsqlConnectionStringBuilder originalConnString)
     {
-        var originalConnStringCopy = originalConnString.Clone();
-        /*
-         * The connectors are created using the Settings initialized in the pool.
-         * When connection strings are different, it will still use the first connection string which was initialized in the pool to create the connection.
-         * So check if connection string is same as the original connection string
-         * if not replace the host in the original conn string with the chosen host in the pool Settings
-         */
-        if (!Settings.Equals(originalConnStringCopy))
+        ConfiguredValueTaskAwaitable<NpgsqlConnector?> awaitableconnector;
+        NpgsqlConnector? connector = null;
+        lock (lockObject)
         {
-            originalConnStringCopy.Host = Settings.Host;
-            Settings = originalConnStringCopy;
+            var originalConnStringCopy = originalConnString.Clone();
+            /*
+             * The connectors are created using the Settings initialized in the pool.
+             * When connection strings are different, it will still use the first connection string which was initialized in the pool to create the connection.
+             * So check if connection string is same as the original connection string
+             * if not replace the host in the original conn string with the chosen host in the pool Settings
+             */
+            if (!Settings.Equals(originalConnStringCopy))
+            {
+                originalConnStringCopy.Host = Settings.Host;
+                Settings = originalConnStringCopy;
+            }
+            // 1. Call base logic → this increments _numConnectors and populates Connectors[]
+            awaitableconnector = base.OpenNewConnector(conn, timeout, async, cancellationToken).ConfigureAwait(false);
         }
-        // 1. Call base logic → this increments _numConnectors and populates Connectors[]
-        var connector = await base.OpenNewConnector(conn, timeout, async, cancellationToken).ConfigureAwait(false);
+
+        connector = await awaitableconnector;
 
         if (connector is not null)
         {

--- a/src/Npgsql/YBPoolingWrapperDataSource.cs
+++ b/src/Npgsql/YBPoolingWrapperDataSource.cs
@@ -96,7 +96,7 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
                     connStringToIdleConnectorsMap[originalConnString] = connectors;
                     if (connStringToConnectorsMap.TryGetValue(originalConnString, out  var list))
                     {
-                        for (var j = 0; i < MaxConnections; i++)
+                        for (var j = 0; j < MaxConnections; j++)
                             if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
                                 break;
                         connStringToConnectorsMap[originalConnString] = list;
@@ -133,7 +133,7 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
                         }
                         if (connStringToIdleConnectorsMap.TryGetValue(connStringToConnectors.Key, out  var list))
                         {
-                            for (var j = 0; i < MaxConnections; i++)
+                            for (var j = 0; j < MaxConnections; j++)
                                 if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
                                     break;
                             connStringToIdleConnectorsMap[connStringToConnectors.Key] = list;
@@ -141,7 +141,7 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
                         else
                         {
                             list = new NpgsqlConnector[MaxConnections];
-                            for (var j = 0; i < MaxConnections; i++)
+                            for (var j = 0; j < MaxConnections; j++)
                                 if (Interlocked.CompareExchange(ref list[j], connector, null) == null)
                                     break;
                             connStringToIdleConnectorsMap[connStringToConnectors.Key] = list;

--- a/src/Npgsql/YBPoolingWrapperDataSource.cs
+++ b/src/Npgsql/YBPoolingWrapperDataSource.cs
@@ -12,8 +12,8 @@ namespace YBNpgsql;
 /// </summary>
 sealed class YBPoolingWrapperDataSource: PoolingDataSource
 {
-    static ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToConnectorsMap = null!;
-    static ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToIdleConnectorsMap = null!;
+    ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToConnectorsMap = null!;
+    ConcurrentDictionary<NpgsqlConnectionStringBuilder, NpgsqlConnector?[]>  connStringToIdleConnectorsMap = null!;
 
     internal YBPoolingWrapperDataSource(NpgsqlConnectionStringBuilder settings, NpgsqlDataSourceConfiguration dataSourceConfiguration) :
         base(settings, dataSourceConfiguration)
@@ -73,7 +73,7 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
         connector = null;
 
         // Try to get the array for this conn string
-        if (!connStringToConnectorsMap.TryGetValue(originalConnString, out var connectors))
+        if (!connStringToIdleConnectorsMap.TryGetValue(originalConnString, out var connectors))
             return false;
 
         // Fast scan for the first non-null, *idle* connector
@@ -87,14 +87,10 @@ sealed class YBPoolingWrapperDataSource: PoolingDataSource
             if (CheckIdleConnector(c))
             {
                 connector = c;
-                if (connStringToIdleConnectorsMap.TryGetValue(originalConnString, out var idleconnectorslist))
-                {
-                    for (var j = 0; j < MaxConnections; j++)
-                        if (Interlocked.CompareExchange(ref idleconnectorslist[j], null, connector) == connector)
-                            break;
-                    connStringToIdleConnectorsMap[originalConnString] = idleconnectorslist;
-
-                }
+                for (var j = 0; j < MaxConnections; j++)
+                    if (Interlocked.CompareExchange(ref connectors[j], null, connector) == connector)
+                        break;
+                connStringToIdleConnectorsMap[originalConnString] = connectors;
                 if (connStringToConnectorsMap.TryGetValue(originalConnString, out  var list))
                 {
                     for (var j = 0; i < MaxConnections; i++)

--- a/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
@@ -61,12 +61,18 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var cmd = "/bin/yb-ctl stop_node 1";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine(_Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine(_Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine(_Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -131,12 +137,18 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine(_Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 5";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine(_Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 6";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine(_Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         try
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, -1, -1, -1});
@@ -208,18 +220,29 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         var cmd = "/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
-        cmd = "/build/latest/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live";
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        cmd = "/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter2.rack1 --tserver_flags placement_uuid=rr";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter3.rack1 --tserver_flags placement_uuid=rr";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter4.rack1 --tserver_flags placement_uuid=rr";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        System.Threading.Thread.Sleep(5000);
     }
 
     protected void DestroyCluster()
@@ -228,6 +251,9 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         string? _Error = null;
         var cmd = "/bin/yb-ctl destroy";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
     }
 
     void CloseConnections(List<NpgsqlConnection> conns)

--- a/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
@@ -217,6 +217,10 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
     {
         string? _Output = null;
         string? _Error = null;
+        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         var cmd = "/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);

--- a/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
@@ -55,24 +55,9 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop node: 127.0.0.1, 127.0.0.2, 127.0.0.3
-
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 1";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine(_Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine(_Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine(_Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 1", "stop node 1");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 3", "stop node 3");
 
         try
         {
@@ -131,24 +116,9 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop node : 127.0.0.4, 127.0.0.5, 127.0.0.6
-
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine(_Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 5";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine(_Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 6";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine(_Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 6", "stop node 6");
         try
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, -1, -1, -1});
@@ -215,49 +185,18 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
 
     void CreateRRCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        var cmd = "/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter2.rack1 --tserver_flags placement_uuid=rr";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter3.rack1 --tserver_flags placement_uuid=rr";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter4.rack1 --tserver_flags placement_uuid=rr";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
+        ExecuteShellCommand("/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"", "create cluster");
+        ExecuteShellCommand("/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live", "modify placement info");
+        ExecuteShellCommand("/bin/yb-ctl add_node --placement_info cloud1.datacenter2.rack1 --tserver_flags placement_uuid=rr", "add RR node (datacenter2)");
+        ExecuteShellCommand("/bin/yb-ctl add_node --placement_info cloud1.datacenter3.rack1 --tserver_flags placement_uuid=rr", "add RR node (datacenter3)");
+        ExecuteShellCommand("/bin/yb-ctl add_node --placement_info cloud1.datacenter4.rack1 --tserver_flags placement_uuid=rr", "add RR node (datacenter4)");
         System.Threading.Thread.Sleep(5000);
     }
 
     protected void DestroyCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl destroy";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
     }
 
     void CloseConnections(List<NpgsqlConnection> conns)

--- a/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBClusterAwareRRSupportTests.cs
@@ -23,11 +23,6 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, 0, 0, 0});
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
         finally
         {
             CloseConnections(conns);
@@ -46,11 +41,6 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, 0, 0, 0});
 
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
         }
         finally
         {
@@ -83,11 +73,6 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             conns = await CreateConnections(connStringBuilder, numConns, new []{-1, -1, -1, numConns / 3, numConns / 3, numConns / 3});
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
         finally
         {
             CloseConnections(conns);
@@ -106,11 +91,7 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns / 3, numConns / 3, numConns / 3});
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -129,11 +110,6 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns / 3, numConns / 3, numConns / 3});
 
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
         }
         finally
         {
@@ -166,11 +142,6 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, -1, -1, -1});
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
         finally
         {
             CloseConnections(conns);
@@ -188,11 +159,6 @@ public class YBClusterAwareRRSupportTests : YBTestUtils{
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 6, numConns / 6, numConns / 6, numConns / 6, numConns / 6, numConns / 6});
 
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
         }
         finally
         {

--- a/test/Npgsql.Tests/YBFallBackTopologyExtended.cs
+++ b/test/Npgsql.Tests/YBFallBackTopologyExtended.cs
@@ -10,11 +10,15 @@ namespace YBNpgsql.Tests;
 public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
 {
     string connStringBuilder = "host=127.0.0.1,127.0.0.5,127.0.0.7;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0;YB Servers Refresh Interval=10;Topology Keys=";
-    int numConnections = 12;
+    int numConnections = 18;
     new void CreateCluster()
     {
         string? _Output = null;
         string? _Error = null;
+        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         var cmd = "/bin/yb-ctl start --rf 3 --placement_info \"aws.us-west.us-west-1a,aws.us-west.us-west-1a,aws.us-west.us-west-1a\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
@@ -139,6 +143,8 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
         if (!string.IsNullOrWhiteSpace(_Error))
             Console.WriteLine("Error:" + _Error);
 
+        Thread.Sleep(15000);
+
         count = new[] { -1, -1, -1, -1, 12, 0 };
         conns = await CreateConnections(connStringBuilder+"aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4", count);
 
@@ -166,7 +172,7 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
 
         Thread.Sleep(15000);
 
-        count = new[] { 6, 6, -1, -1, -1, -1 };
+        count = new[] { 6, 6, -1, 0, 0, 0 };
         conns = await CreateConnections(connStringBuilder+"aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4", count);
 
         DestroyCluster();
@@ -268,9 +274,12 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
     }
 
     [Test, Timeout(240000)]
-    private async Task checkNodeDownPrimary() {
+    public async Task checkNodeDownPrimary() {
       string? _Output = null;
       string? _Error = null;
+
+      var savedConnString = connStringBuilder;
+      connStringBuilder = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0;YB Servers Refresh Interval=10;Topology Keys=";
 
       ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
       Console.WriteLine("Output:" + _Output);
@@ -283,6 +292,7 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
       if (!string.IsNullOrWhiteSpace(_Error))
           Console.WriteLine("Error:" + _Error);
 
+      Thread.Sleep(15000);
       try {
           await createConnectionsWithoutCloseAndVerify( "aws.us-west.*:1", new[]{6, 6, 6});
           ExecuteShellCommand("/bin/yb-ctl stop_node 1", ref _Output, ref _Error);
@@ -300,7 +310,8 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
           await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1", new[]{16, 16, 16});
 
       } finally {
-          ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+          connStringBuilder = savedConnString;
+          ExecuteShellCommand("/bin/yb-ctl status", ref _Output, ref _Error);
           Console.WriteLine("Output:" + _Output);
           if (!string.IsNullOrWhiteSpace(_Error))
               Console.WriteLine("Error:" + _Error);

--- a/test/Npgsql.Tests/YBFallBackTopologyExtended.cs
+++ b/test/Npgsql.Tests/YBFallBackTopologyExtended.cs
@@ -13,78 +13,34 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
     int numConnections = 18;
     new void CreateCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
         var cmd = "/bin/yb-ctl start --rf 3 --placement_info \"aws.us-west.us-west-1a,aws.us-west.us-west-1a,aws.us-west.us-west-1a\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "start cluster");
         cmd = "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2a\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "add node (us-east-2a)");
         cmd = "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2b\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "add node (us-east-2b)");
         cmd = "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2c\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "add node (us-east-2c)");
     }
     void startYBDBClusterWithNineNodes() {
 
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand( "/bin/yb-ctl destroy",  ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand( "/bin/yb-ctl destroy", "destroy cluster");
 
         ExecuteShellCommand( "/bin/yb-ctl --rf 3 start --placement_info \"aws.us-west.us-west-1a\" ",
-            ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+            "start cluster");
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2a\"",
-            ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+            "add node (us-east-2a)");
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2a\"",
-            ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+            "add node (us-east-2a)");
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.eu-north.eu-north-2a\"",
-            ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-
+            "add node (eu-north-2a)");
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.eu-west.eu-west-2a\"",
-            ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+            "add node (eu-west-2a)");
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.eu-west.eu-west-2a\"",
-            ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+            "add node (eu-west-2a)");
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.eu-north.eu-north-2a\"",
-            ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+            "add node (eu-north-2a)");
         Thread.Sleep(5000);
     }
 
@@ -112,36 +68,21 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
     public async Task TestFallback()
     {
 
-        string? _Output = null;
-        string? _Error = null;
-
         CreateCluster();
         int[] count = { 4, 4, 4, 0, 0, 0 };
         var conns = await CreateConnections(connStringBuilder+"aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4", count);
 
         var cmd = "/bin/yb-ctl stop_node 1";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "stop node 1");
 
         cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "stop node 2");
 
         cmd = "/bin/yb-ctl stop_node 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "stop node 3");
 
         cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "stop node 4");
 
         Thread.Sleep(15000);
 
@@ -149,26 +90,17 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
         conns = await CreateConnections(connStringBuilder+"aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4", count);
 
         cmd = "/bin/yb-ctl start_node 4 --placement_info \"aws.us-east.us-east-2a\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "start node 4 (aws.us-east.us-east-2a)");
         Thread.Sleep(15000);
 
         count = new[] { -1, -1, -1, 12, 0, 0 };
         conns = await CreateConnections(connStringBuilder+"aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4", count);
 
         cmd = "/bin/yb-ctl start_node 1 --placement_info \"aws.us-west.us-west-1a\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "start node 1 (aws.us-west.us-west-1a)");
 
         cmd = "/bin/yb-ctl start_node 2 --placement_info \"aws.us-west.us-west-1a\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "start node 2 (aws.us-west.us-west-1a)");
 
         Thread.Sleep(15000);
 
@@ -184,137 +116,79 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
     // and 127.0.0.4 -> us-east-2a, 127.0.0.5 -> us-east-2a and 127.0.0.6 -> eu-north-2a, 127.0.0.9 -> eu-north-2a,
     // and 127.0.0.7 -> eu-west-2a, 127.0.0.8 -> eu-west-2a.
     startYBDBClusterWithNineNodes();
-    string? _Output = null;
-    string? _Error = null;
 
     try
     {
         await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                      ".*:3,aws.eu-north.*:4", new[] { 6, 6, 6, 0, 0, 0, 0, 0, 0 });
 
-        ExecuteShellCommand("/bin/yb-ctl stop_node 1", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        ExecuteShellCommand("/bin/yb-ctl stop_node 2", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        ExecuteShellCommand("/bin/yb-ctl stop_node 3", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        ExecuteShellCommand("/bin/yb-ctl stop_node 4", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        ExecuteShellCommand("/bin/yb-ctl stop_node 5", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        ExecuteShellCommand("/bin/yb-ctl stop_node 7", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        ExecuteShellCommand("/bin/yb-ctl stop_node 8", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 1", "stop node 1");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 3", "stop node 3");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 7", "stop node 7");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 8", "stop node 8");
         await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                      ".*:3,aws.eu-north.*:4", new[] { -1, -1, -1, -1, -1, 9, -1, -1, 9 });
 
-        ExecuteShellCommand("/bin/yb-ctl stop_node 9", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 9", "stop node 9");
         await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                      ".*:3,aws.eu-north.*:4", new[] { -1, -1, -1, -1, -1, 27, -1, -1, -1 });
 
         ExecuteShellCommand("/bin/yb-ctl start_node 2 --placement_info \"aws.us-west.us-west-1a\"",
-            ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+            "start node 2 (aws.us-west.us-west-1a)");
 
         Thread.Sleep(15000);
 
         await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                      ".*:3,aws.eu-north.*:4", new[] { -1, 18, -1, -1, -1, 27, -1, -1, -1 });
 
-        ExecuteShellCommand("/bin/yb-ctl stop_node 2", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
         await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                      ".*:3,aws.eu-north.*:4", new[]{-1, -1, -1, -1, -1, 45, -1, -1, -1 });
 
-      ExecuteShellCommand("/bin/yb-ctl start_node 5 --placement_info \"aws.us-east.us-east-2a\"", ref _Output, ref _Error );
-      Console.WriteLine("Output:" + _Output);
-      if (!string.IsNullOrWhiteSpace(_Error))
-          Console.WriteLine("Error:" + _Error);
+      ExecuteShellCommand("/bin/yb-ctl start_node 5 --placement_info \"aws.us-east.us-east-2a\"", "start node 5 (aws.us-east.us-east-2a)");
 
       Thread.Sleep(15000);
 
       await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                        ".*:3,aws.eu-north.*:4", new[]{-1, -1, -1, -1, 18, 45, -1, -1, -1});
 
-      ExecuteShellCommand("/bin/yb-ctl stop_node 5", ref _Output, ref _Error );
-      Console.WriteLine("Output:" + _Output);
-      if (!string.IsNullOrWhiteSpace(_Error))
-          Console.WriteLine("Error:" + _Error);
+      ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
       await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                        ".*:3,aws.eu-north.*:4", new[]{-1, -1, -1, -1, -1, 63, -1, -1, -1});
 
     } finally {
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
     }
     }
 
     [Test, Timeout(240000)]
     public async Task checkNodeDownPrimary() {
-      string? _Output = null;
-      string? _Error = null;
 
       var savedConnString = connStringBuilder;
       connStringBuilder = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0;YB Servers Refresh Interval=10;Topology Keys=";
 
-      ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-      Console.WriteLine("Output:" + _Output);
-      if (!string.IsNullOrWhiteSpace(_Error))
-          Console.WriteLine("Error:" + _Error);
+      ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
 
       ExecuteShellCommand("/bin/yb-ctl --rf 3 start --placement_info \"aws.us-west.us-west-1a\" ",
-          ref _Output, ref _Error);
-      Console.WriteLine("Output:" + _Output);
-      if (!string.IsNullOrWhiteSpace(_Error))
-          Console.WriteLine("Error:" + _Error);
+          "start cluster");
 
       Thread.Sleep(15000);
       try {
           await createConnectionsWithoutCloseAndVerify( "aws.us-west.*:1", new[]{6, 6, 6});
-          ExecuteShellCommand("/bin/yb-ctl stop_node 1", ref _Output, ref _Error);
-          Console.WriteLine("Output:" + _Output);
-          if (!string.IsNullOrWhiteSpace(_Error))
-              Console.WriteLine("Error:" + _Error);
+          ExecuteShellCommand("/bin/yb-ctl stop_node 1", "stop node 1");
           await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1", new[]{-1, 15, 15});
           ExecuteShellCommand("/bin/yb-ctl start_node 1 --placement_info \"aws.us-west.us-west-1a\"",
-          ref _Output, ref _Error);
-          Console.WriteLine("Output:" + _Output);
-          if (!string.IsNullOrWhiteSpace(_Error))
-              Console.WriteLine("Error:" + _Error);
+          "start node 1 (aws.us-west.us-west-1a)");
           ClusterAwareDataSource.forceRefresh = true;
           Thread.Sleep(5000);
           await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1", new[]{16, 16, 16});
 
       } finally {
           connStringBuilder = savedConnString;
-          ExecuteShellCommand("/bin/yb-ctl status", ref _Output, ref _Error);
-          Console.WriteLine("Output:" + _Output);
-          if (!string.IsNullOrWhiteSpace(_Error))
-              Console.WriteLine("Error:" + _Error);
+          ExecuteShellCommand("/bin/yb-ctl status", "cluster status");
       }
   }
 }

--- a/test/Npgsql.Tests/YBFallBackTopologyExtended.cs
+++ b/test/Npgsql.Tests/YBFallBackTopologyExtended.cs
@@ -18,37 +18,69 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
         var cmd = "/bin/yb-ctl start --rf 3 --placement_info \"aws.us-west.us-west-1a,aws.us-west.us-west-1a,aws.us-west.us-west-1a\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2a\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2b\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2c\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
     }
     void startYBDBClusterWithNineNodes() {
 
         string? _Output = null;
         string? _Error = null;
         ExecuteShellCommand( "/bin/yb-ctl destroy",  ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         ExecuteShellCommand( "/bin/yb-ctl --rf 3 start --placement_info \"aws.us-west.us-west-1a\" ",
             ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2a\"",
             ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.us-east.us-east-2a\"",
             ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.eu-north.eu-north-2a\"",
             ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.eu-west.eu-west-2a\"",
             ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.eu-west.eu-west-2a\"",
             ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand( "/bin/yb-ctl add_node --placement_info \"aws.eu-north.eu-north-2a\"",
             ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         Thread.Sleep(5000);
     }
 
@@ -86,18 +118,26 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
         var cmd = "/bin/yb-ctl stop_node 1";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         cmd = "/bin/yb-ctl stop_node 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         count = new[] { -1, -1, -1, -1, 12, 0 };
         conns = await CreateConnections(connStringBuilder+"aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4", count);
@@ -105,6 +145,8 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
         cmd = "/bin/yb-ctl start_node 4 --placement_info \"aws.us-east.us-east-2a\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         Thread.Sleep(15000);
 
         count = new[] { -1, -1, -1, 12, 0, 0 };
@@ -113,10 +155,14 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
         cmd = "/bin/yb-ctl start_node 1 --placement_info \"aws.us-west.us-west-1a\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         cmd = "/bin/yb-ctl start_node 2 --placement_info \"aws.us-west.us-west-1a\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         Thread.Sleep(15000);
 
@@ -126,7 +172,7 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
         DestroyCluster();
     }
 
-    [Test]
+    [Test, Timeout(240000)]
     public async Task CheckMultiNodeDown(){
     // Start RF=3 cluster with 9 nodes and with placements (127.0.0.1, 127.0.0.2, 127.0.0.3) -> us-west-1a,
     // and 127.0.0.4 -> us-east-2a, 127.0.0.5 -> us-east-2a and 127.0.0.6 -> eu-north-2a, 127.0.0.9 -> eu-north-2a,
@@ -141,21 +187,48 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
                                                      ".*:3,aws.eu-north.*:4", new[] { 6, 6, 6, 0, 0, 0, 0, 0, 0 });
 
         ExecuteShellCommand("/bin/yb-ctl stop_node 1", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand("/bin/yb-ctl stop_node 2", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand("/bin/yb-ctl stop_node 3", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand("/bin/yb-ctl stop_node 4", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand("/bin/yb-ctl stop_node 5", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand("/bin/yb-ctl stop_node 7", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         ExecuteShellCommand("/bin/yb-ctl stop_node 8", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                      ".*:3,aws.eu-north.*:4", new[] { -1, -1, -1, -1, -1, 9, -1, -1, 9 });
 
         ExecuteShellCommand("/bin/yb-ctl stop_node 9", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                      ".*:3,aws.eu-north.*:4", new[] { -1, -1, -1, -1, -1, 27, -1, -1, -1 });
 
         ExecuteShellCommand("/bin/yb-ctl start_node 2 --placement_info \"aws.us-west.us-west-1a\"",
             ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         Thread.Sleep(15000);
 
@@ -163,10 +236,16 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
                                                      ".*:3,aws.eu-north.*:4", new[] { -1, 18, -1, -1, -1, 27, -1, -1, -1 });
 
         ExecuteShellCommand("/bin/yb-ctl stop_node 2", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                      ".*:3,aws.eu-north.*:4", new[]{-1, -1, -1, -1, -1, 45, -1, -1, -1 });
 
       ExecuteShellCommand("/bin/yb-ctl start_node 5 --placement_info \"aws.us-east.us-east-2a\"", ref _Output, ref _Error );
+      Console.WriteLine("Output:" + _Output);
+      if (!string.IsNullOrWhiteSpace(_Error))
+          Console.WriteLine("Error:" + _Error);
 
       Thread.Sleep(15000);
 
@@ -174,36 +253,57 @@ public class YBFallBackTopologyExtended : YBFallbackTopolgyTests
                                                        ".*:3,aws.eu-north.*:4", new[]{-1, -1, -1, -1, 18, 45, -1, -1, -1});
 
       ExecuteShellCommand("/bin/yb-ctl stop_node 5", ref _Output, ref _Error );
+      Console.WriteLine("Output:" + _Output);
+      if (!string.IsNullOrWhiteSpace(_Error))
+          Console.WriteLine("Error:" + _Error);
       await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1,aws.us-east.*:2,aws.eu-west" +
                                                        ".*:3,aws.eu-north.*:4", new[]{-1, -1, -1, -1, -1, 63, -1, -1, -1});
 
     } finally {
         ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
     }
     }
 
-    [Test]
+    [Test, Timeout(240000)]
     private async Task checkNodeDownPrimary() {
       string? _Output = null;
       string? _Error = null;
 
       ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+      Console.WriteLine("Output:" + _Output);
+      if (!string.IsNullOrWhiteSpace(_Error))
+          Console.WriteLine("Error:" + _Error);
 
       ExecuteShellCommand("/bin/yb-ctl --rf 3 start --placement_info \"aws.us-west.us-west-1a\" ",
           ref _Output, ref _Error);
+      Console.WriteLine("Output:" + _Output);
+      if (!string.IsNullOrWhiteSpace(_Error))
+          Console.WriteLine("Error:" + _Error);
 
       try {
           await createConnectionsWithoutCloseAndVerify( "aws.us-west.*:1", new[]{6, 6, 6});
           ExecuteShellCommand("/bin/yb-ctl stop_node 1", ref _Output, ref _Error);
+          Console.WriteLine("Output:" + _Output);
+          if (!string.IsNullOrWhiteSpace(_Error))
+              Console.WriteLine("Error:" + _Error);
           await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1", new[]{-1, 15, 15});
           ExecuteShellCommand("/bin/yb-ctl start_node 1 --placement_info \"aws.us-west.us-west-1a\"",
           ref _Output, ref _Error);
+          Console.WriteLine("Output:" + _Output);
+          if (!string.IsNullOrWhiteSpace(_Error))
+              Console.WriteLine("Error:" + _Error);
           ClusterAwareDataSource.forceRefresh = true;
           Thread.Sleep(5000);
           await createConnectionsWithoutCloseAndVerify("aws.us-west.*:1", new[]{16, 16, 16});
 
       } finally {
           ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+          Console.WriteLine("Output:" + _Output);
+          if (!string.IsNullOrWhiteSpace(_Error))
+              Console.WriteLine("Error:" + _Error);
       }
   }
 }

--- a/test/Npgsql.Tests/YBFallbackTopolgyTests.cs
+++ b/test/Npgsql.Tests/YBFallbackTopolgyTests.cs
@@ -59,13 +59,7 @@ public class YBFallbackTopolgyTests : YBTestUtils
 
         await VerifyOn("127.0.0.1", 1);
 
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 1";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine(_Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 1", "stop node 1");
 
         var conns = await CreateConnections(connString, new[]{-1, 12, 0});
 
@@ -84,13 +78,7 @@ public class YBFallbackTopolgyTests : YBTestUtils
 
         await VerifyOn("127.0.0.1", 1);
 
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 1";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine(_Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 1", "stop node 1");
 
         var conns = await CreateConnections(connString, new[]{-1, 6, 6});
         CloseConnections(conns);
@@ -161,29 +149,15 @@ public class YBFallbackTopolgyTests : YBTestUtils
 
     protected void CreateCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
         var cmd = "/bin/yb-ctl start --rf 3 --placement_info \"aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "start cluster");
         System.Threading.Thread.Sleep(5000);
     }
 
     protected void DestroyCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl destroy";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
     }
 
 }

--- a/test/Npgsql.Tests/YBFallbackTopolgyTests.cs
+++ b/test/Npgsql.Tests/YBFallbackTopolgyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -147,6 +148,12 @@ public class YBFallbackTopolgyTests : YBTestUtils
                 conn.Close();
             }
         }
+        // conn.Close() with pooling enabled returns the connection to the pool
+        // rather than closing the physical TCP connection. ClearAllPools()
+        // forces physical disconnection, and the sleep lets the server
+        // register the disconnections before we verify counts via rpcz.
+        NpgsqlConnection.ClearAllPools();
+        Thread.Sleep(1000);
         VerifyLocal("127.0.0.1", 0);
         VerifyLocal("127.0.0.2", 0);
         VerifyLocal("127.0.0.3", 0);
@@ -156,6 +163,10 @@ public class YBFallbackTopolgyTests : YBTestUtils
     {
         string? _Output = null;
         string? _Error = null;
+        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         var cmd = "/bin/yb-ctl start --rf 3 --placement_info \"aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);

--- a/test/Npgsql.Tests/YBFallbackTopolgyTests.cs
+++ b/test/Npgsql.Tests/YBFallbackTopolgyTests.cs
@@ -12,7 +12,7 @@ public class YBFallbackTopolgyTests : YBTestUtils
     static int mlock = 0;
     string connStringBuilder = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0;Topology Keys=";
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestFallback1()
     {
         CreateCluster();
@@ -20,7 +20,7 @@ public class YBFallbackTopolgyTests : YBTestUtils
         CloseConnections(conns);
         DestroyCluster();
     }
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestFallback2()
     {
         CreateCluster();
@@ -29,7 +29,7 @@ public class YBFallbackTopolgyTests : YBTestUtils
         DestroyCluster();
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestFallback3()
     {
         CreateCluster();
@@ -38,7 +38,7 @@ public class YBFallbackTopolgyTests : YBTestUtils
         DestroyCluster();
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestFallback4()
     {
         CreateCluster();
@@ -47,7 +47,7 @@ public class YBFallbackTopolgyTests : YBTestUtils
         DestroyCluster();
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestFallback5()
     {
         CreateCluster();
@@ -63,6 +63,8 @@ public class YBFallbackTopolgyTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 1";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine(_Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         var conns = await CreateConnections(connString, new[]{-1, 12, 0});
 
@@ -70,7 +72,7 @@ public class YBFallbackTopolgyTests : YBTestUtils
         DestroyCluster();
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestFallback6()
     {
         CreateCluster();
@@ -86,6 +88,8 @@ public class YBFallbackTopolgyTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 1";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine(_Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         var conns = await CreateConnections(connString, new[]{-1, 6, 6});
         CloseConnections(conns);
@@ -155,6 +159,9 @@ public class YBFallbackTopolgyTests : YBTestUtils
         var cmd = "/bin/yb-ctl start --rf 3 --placement_info \"aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        System.Threading.Thread.Sleep(5000);
     }
 
     protected void DestroyCluster()
@@ -163,6 +170,9 @@ public class YBFallbackTopolgyTests : YBTestUtils
         string? _Error = null;
         var cmd = "/bin/yb-ctl destroy";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
     }
 
 }

--- a/test/Npgsql.Tests/YBLoadBalancerTests.cs
+++ b/test/Npgsql.Tests/YBLoadBalancerTests.cs
@@ -55,13 +55,7 @@ public class YBLoadBalancerTests : YBTestUtils
                 var conn1 = CreateConnections(connStringBuilder, numConns);
                 conns.AddRange(conn1);
 
-                string? _Output = null;
-                string? _Error = null;
-                var cmd = "/bin/yb-ctl stop_node 1";
-                ExecuteShellCommand(cmd, ref _Output, ref _Error );
-                Console.WriteLine(_Output);
-                if (!string.IsNullOrWhiteSpace(_Error))
-                    Console.WriteLine("Error:" + _Error);
+                ExecuteShellCommand("/bin/yb-ctl stop_node 1", "stop node 1");
 
                 var conn2 = CreateConnections(connStringBuilder, numConns);
                 conns.AddRange(conn2);
@@ -139,29 +133,14 @@ public class YBLoadBalancerTests : YBTestUtils
 
     void CreateCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        var cmd = "/bin/yb-ctl create --rf 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
+        ExecuteShellCommand("/bin/yb-ctl create --rf 3", "create cluster");
         System.Threading.Thread.Sleep(5000);
     }
 
     void DestroyCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl destroy";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
     }
 
     static List<NpgsqlConnection> CreateConnections(string connString, int numConns)

--- a/test/Npgsql.Tests/YBLoadBalancerTests.cs
+++ b/test/Npgsql.Tests/YBLoadBalancerTests.cs
@@ -141,6 +141,10 @@ public class YBLoadBalancerTests : YBTestUtils
     {
         string? _Output = null;
         string? _Error = null;
+        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         var cmd = "/bin/yb-ctl create --rf 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);

--- a/test/Npgsql.Tests/YBLoadBalancerTests.cs
+++ b/test/Npgsql.Tests/YBLoadBalancerTests.cs
@@ -32,12 +32,12 @@ public class YBLoadBalancerTests : YBTestUtils
             conn.Open();
             conn.Close();
             conn1.Open();
-            // for (int i = 0; i < 6; i++)
-            // {
-            //     NpgsqlConnection conn3 = new NpgsqlConnection(connStringBuilder1);
-            //     conn3.Open();
-            //     conns.Add(conn3);
-            // }
+            for (var i = 0; i < 6; i++)
+            {
+                NpgsqlConnection conn3 = new NpgsqlConnection(connStringBuilder1);
+                conn3.Open();
+                conns.Add(conn3);
+            }
             conn2.Open();
 
             // NpgsqlCommand cmd = new NpgsqlCommand("SELECT current_user;", conn);

--- a/test/Npgsql.Tests/YBLoadBalancerTests.cs
+++ b/test/Npgsql.Tests/YBLoadBalancerTests.cs
@@ -13,38 +13,77 @@ public class YBLoadBalancerTests : YBTestUtils
     int numConns = 6;
 
     [Test]
-    public async Task TestLoadBalance1()
+    public void TestLoadBalance1()
     {
-        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=any;Timeout=0";
+        var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Timeout=0;";
+        var connStringBuilder2 = "host=127.0.0.1;database=yugabyte;userid=tester;password=abc123;Load Balance Hosts=any;Timeout=0;";
+
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        CreateCluster();
+        // CreateCluster();
 
         try
         {
-            conns = CreateConnections(connStringBuilder, numConns);
-            await VerifyOn("127.0.0.1", numConns/3);
-            await VerifyOn("127.0.0.2", numConns/3);
-            await VerifyOn("127.0.0.3", numConns / 3);
+            // for (var i = 1; i <= numConns; i++)
+            // {
+            NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder1);
+            NpgsqlConnection conn1 = new NpgsqlConnection(connStringBuilder1);
+            NpgsqlConnection conn2 = new NpgsqlConnection(connStringBuilder2);
+            conn.Open();
+            conn.Close();
+            conn1.Open();
+            // for (int i = 0; i < 6; i++)
+            // {
+            //     NpgsqlConnection conn3 = new NpgsqlConnection(connStringBuilder1);
+            //     conn3.Open();
+            //     conns.Add(conn3);
+            // }
+            conn2.Open();
 
+            // NpgsqlCommand cmd = new NpgsqlCommand("SELECT current_user;", conn);
+            // NpgsqlDataReader reader = cmd.ExecuteReader();
+            // Console.WriteLine("User 1: ");
+            // while (reader.Read())
+            // {
+            //     Console.WriteLine("{0}", reader.GetString(0));
+            // }
+
+            NpgsqlCommand cmd1 = new NpgsqlCommand("SELECT current_user;", conn1);
+            NpgsqlDataReader reader1 = cmd1.ExecuteReader();
+            Console.WriteLine("User 1: ");
+            while (reader1.Read())
+            {
+                Console.WriteLine("{0}", reader1.GetString(0));
+            }
+            // }
+
+            NpgsqlCommand cmd2 = new NpgsqlCommand("SELECT current_user;", conn2);
+            NpgsqlDataReader reader2 = cmd2.ExecuteReader();
+            Console.WriteLine("User 2: ");
+            while (reader2.Read())
+            {
+                Console.WriteLine("{0}", reader2.GetString(0));
+            }
+
+            Console.WriteLine("Connections Created");
         }
         catch (Exception ex)
         {
             Console.WriteLine("Failure:" + ex.Message);
             Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
         }
-        finally
-        {
-            foreach (var conn in conns)
-            {
-                conn.Close();
-            }
-            Console.WriteLine("Verifying if all connections are closed...");
-            VerifyLocal("127.0.0.1", 0);
-            VerifyLocal("127.0.0.2", 0);
-            VerifyLocal("127.0.0.3", 0);
-            DestroyCluster();
-        }
+        // finally
+        // {
+        //     foreach (var conn in conns)
+        //     {
+        //         conn.Close();
+        //     }
+        //     Console.WriteLine("Verifying if all connections are closed...");
+        //     // VerifyLocal("127.0.0.1", 0);
+        //     // VerifyLocal("127.0.0.2", 0);
+        //     // VerifyLocal("127.0.0.3", 0);
+        //     // DestroyCluster();
+        // }
     }
 
     [Test]

--- a/test/Npgsql.Tests/YBLoadBalancerTests.cs
+++ b/test/Npgsql.Tests/YBLoadBalancerTests.cs
@@ -13,77 +13,38 @@ public class YBLoadBalancerTests : YBTestUtils
     int numConns = 6;
 
     [Test]
-    public void TestLoadBalance1()
+    public async Task TestLoadBalance1()
     {
-        var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Timeout=0;";
-        var connStringBuilder2 = "host=127.0.0.1;database=yugabyte;userid=tester;password=abc123;Load Balance Hosts=any;Timeout=0;";
-
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=any;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
-        // CreateCluster();
+        CreateCluster();
 
         try
         {
-            // for (var i = 1; i <= numConns; i++)
-            // {
-            NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder1);
-            NpgsqlConnection conn1 = new NpgsqlConnection(connStringBuilder1);
-            NpgsqlConnection conn2 = new NpgsqlConnection(connStringBuilder2);
-            conn.Open();
-            conn.Close();
-            conn1.Open();
-            for (var i = 0; i < 6; i++)
-            {
-                NpgsqlConnection conn3 = new NpgsqlConnection(connStringBuilder1);
-                conn3.Open();
-                conns.Add(conn3);
-            }
-            conn2.Open();
+            conns = CreateConnections(connStringBuilder, numConns);
+            await VerifyOn("127.0.0.1", numConns/3);
+            await VerifyOn("127.0.0.2", numConns/3);
+            await VerifyOn("127.0.0.3", numConns / 3);
 
-            // NpgsqlCommand cmd = new NpgsqlCommand("SELECT current_user;", conn);
-            // NpgsqlDataReader reader = cmd.ExecuteReader();
-            // Console.WriteLine("User 1: ");
-            // while (reader.Read())
-            // {
-            //     Console.WriteLine("{0}", reader.GetString(0));
-            // }
-
-            NpgsqlCommand cmd1 = new NpgsqlCommand("SELECT current_user;", conn1);
-            NpgsqlDataReader reader1 = cmd1.ExecuteReader();
-            Console.WriteLine("User 1: ");
-            while (reader1.Read())
-            {
-                Console.WriteLine("{0}", reader1.GetString(0));
-            }
-            // }
-
-            NpgsqlCommand cmd2 = new NpgsqlCommand("SELECT current_user;", conn2);
-            NpgsqlDataReader reader2 = cmd2.ExecuteReader();
-            Console.WriteLine("User 2: ");
-            while (reader2.Read())
-            {
-                Console.WriteLine("{0}", reader2.GetString(0));
-            }
-
-            Console.WriteLine("Connections Created");
         }
         catch (Exception ex)
         {
             Console.WriteLine("Failure:" + ex.Message);
             Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
         }
-        // finally
-        // {
-        //     foreach (var conn in conns)
-        //     {
-        //         conn.Close();
-        //     }
-        //     Console.WriteLine("Verifying if all connections are closed...");
-        //     // VerifyLocal("127.0.0.1", 0);
-        //     // VerifyLocal("127.0.0.2", 0);
-        //     // VerifyLocal("127.0.0.3", 0);
-        //     // DestroyCluster();
-        // }
+        finally
+        {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
+            Console.WriteLine("Verifying if all connections are closed...");
+            VerifyLocal("127.0.0.1", 0);
+            VerifyLocal("127.0.0.2", 0);
+            VerifyLocal("127.0.0.3", 0);
+            DestroyCluster();
+        }
     }
 
     [Test]

--- a/test/Npgsql.Tests/YBLoadBalancerTests.cs
+++ b/test/Npgsql.Tests/YBLoadBalancerTests.cs
@@ -12,7 +12,7 @@ public class YBLoadBalancerTests : YBTestUtils
 {
     int numConns = 6;
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestLoadBalance1()
     {
         var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=any;Timeout=0";
@@ -43,7 +43,7 @@ public class YBLoadBalancerTests : YBTestUtils
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestLoadBalance2()
         {
             var connStringBuilder = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;YB Servers Refresh Interval=30;Timeout=0";
@@ -60,8 +60,8 @@ public class YBLoadBalancerTests : YBTestUtils
                 var cmd = "/bin/yb-ctl stop_node 1";
                 ExecuteShellCommand(cmd, ref _Output, ref _Error );
                 Console.WriteLine(_Output);
-
-                System.Threading.Thread.Sleep(30000);
+                if (!string.IsNullOrWhiteSpace(_Error))
+                    Console.WriteLine("Error:" + _Error);
 
                 var conn2 = CreateConnections(connStringBuilder, numConns);
                 conns.AddRange(conn2);
@@ -85,7 +85,7 @@ public class YBLoadBalancerTests : YBTestUtils
             }
         }
 
-    [Test]
+    [Test, Timeout(60000)]
     public async Task TestLoadBalance3()
     {
         var connStringBuilder = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugsbyte;Load Balance Hosts=true;Timeout=0";
@@ -144,6 +144,9 @@ public class YBLoadBalancerTests : YBTestUtils
         var cmd = "/bin/yb-ctl create --rf 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        System.Threading.Thread.Sleep(5000);
     }
 
     void DestroyCluster()
@@ -152,6 +155,9 @@ public class YBLoadBalancerTests : YBTestUtils
         string? _Error = null;
         var cmd = "/bin/yb-ctl destroy";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
     }
 
     static List<NpgsqlConnection> CreateConnections(string connString, int numConns)

--- a/test/Npgsql.Tests/YBLoadBalancerTests.cs
+++ b/test/Npgsql.Tests/YBLoadBalancerTests.cs
@@ -28,11 +28,7 @@ public class YBLoadBalancerTests : YBTestUtils
             await VerifyOn("127.0.0.3", numConns / 3);
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             foreach (var conn in conns)
@@ -73,11 +69,7 @@ public class YBLoadBalancerTests : YBTestUtils
                 await VerifyOn("127.0.0.2", 5);
                 await VerifyOn("127.0.0.3", 5);
             }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Failure:" + ex.Message);
-                Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-            }
+
             finally
             {
                 foreach (var conn in conns)
@@ -130,11 +122,7 @@ public class YBLoadBalancerTests : YBTestUtils
             await VerifyOn("127.0.0.2", numThreads * numConns/3);
             await VerifyOn("127.0.0.3", numThreads * numConns / 3);
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             Console.WriteLine("Conns count" + allConns.Count);

--- a/test/Npgsql.Tests/YBPoolingWrapperTests.cs
+++ b/test/Npgsql.Tests/YBPoolingWrapperTests.cs
@@ -9,7 +9,7 @@ namespace YBNpgsql.Tests;
 public class YBPoolingWrapperTests : YBTestUtils
 {
     [Test]
-    public void TestPoolingForMultileConnStrings()
+    public void TestPoolingForMultipleConnStrings()
     {
         var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Timeout=0;";
         var connStringBuilder2 = "host=127.0.0.1;database=yugabyte;userid=tester;password=abc123;Load Balance Hosts=any;Timeout=0;";
@@ -57,12 +57,16 @@ public class YBPoolingWrapperTests : YBTestUtils
         }
         finally
         {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
             DestroyCluster();
         }
     }
 
     [Test]
-    public void TestPoolingForMultileConnStringsWithTopologyKeys()
+    public void TestPoolingForMultipleConnStringsWithTopologyKeys()
     {
         var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Topology Keys=cloud1.datacenter1.rack1:1;Timeout=0;";
         var connStringBuilder2 = "host=127.0.0.1;database=yugabyte;userid=tester;password=abc123;Load Balance Hosts=any;Topology Keys=cloud1.datacenter1.rack1:1;Timeout=0;";
@@ -110,12 +114,16 @@ public class YBPoolingWrapperTests : YBTestUtils
         }
         finally
         {
+            foreach (var conn in conns)
+            {
+                conn.Close();
+            }
             DestroyCluster();
         }
     }
 
     [Test]
-    public void TestPoolingForMultileConnStringsMultiThread()
+    public void TestPoolingForMultipleConnStringsMultiThread()
     {
         var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Timeout=0;";
         var connStringBuilder2 = "host=127.0.0.1;database=yugabyte;userid=tester;password=abc123;Load Balance Hosts=any;Timeout=0;";
@@ -183,6 +191,14 @@ public class YBPoolingWrapperTests : YBTestUtils
         }
         finally
         {
+            foreach (var conn in conns1)
+            {
+                conn.Close();
+            }
+            foreach (var conn in conns2)
+            {
+                conn.Close();
+            }
             DestroyCluster();
         }
     }

--- a/test/Npgsql.Tests/YBPoolingWrapperTests.cs
+++ b/test/Npgsql.Tests/YBPoolingWrapperTests.cs
@@ -228,38 +228,19 @@ public class YBPoolingWrapperTests : YBTestUtils
     }
     void CreateCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
         var cmd = "/bin/yb-ctl create --rf 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "create cluster");
         System.Threading.Thread.Sleep(5000);
         cmd = "/bin/ysqlsh -c \\\"CREATE USER tester WITH PASSWORD 'abc123'\\\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "create user tester");
         cmd = "/bin/ysqlsh -c \\\"GRANT ALL PRIVILEGES ON DATABASE \\\"yugabyte\\\" to tester;\\\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "grant privileges to tester");
     }
 
     void DestroyCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
         var cmd = "/bin/yb-ctl destroy";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand(cmd, "destroy cluster");
     }
 }

--- a/test/Npgsql.Tests/YBPoolingWrapperTests.cs
+++ b/test/Npgsql.Tests/YBPoolingWrapperTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace YBNpgsql.Tests;
+
+public class YBPoolingWrapperTests : YBTestUtils
+{
+    [Test]
+    public void TestPoolingForMultileConnStrings()
+    {
+        var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Timeout=0;";
+        var connStringBuilder2 = "host=127.0.0.1;database=yugabyte;userid=tester;password=abc123;Load Balance Hosts=any;Timeout=0;";
+
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        CreateCluster();
+
+        try
+        {
+            NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder1);
+            NpgsqlConnection conn1 = new NpgsqlConnection(connStringBuilder1);
+            NpgsqlConnection conn2 = new NpgsqlConnection(connStringBuilder2);
+            conn.Open();
+            conn.Close();
+            conn1.Open();
+            for (var i = 0; i < 6; i++)
+            {
+                NpgsqlConnection conn3 = new NpgsqlConnection(connStringBuilder1);
+                conn3.Open();
+                conns.Add(conn3);
+            }
+            conn2.Open();
+
+            NpgsqlCommand cmd1 = new NpgsqlCommand("SELECT current_user;", conn1);
+            NpgsqlDataReader reader1 = cmd1.ExecuteReader();
+            while (reader1.Read())
+            {
+                Assert.AreEqual(reader1.GetString(0), "postgres");
+            }
+
+            NpgsqlCommand cmd2 = new NpgsqlCommand("SELECT current_user;", conn2);
+            NpgsqlDataReader reader2 = cmd2.ExecuteReader();
+            while (reader2.Read())
+            {
+                Assert.AreEqual(reader2.GetString(0), "tester");
+            }
+
+            Console.WriteLine("Connections Created");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            DestroyCluster();
+        }
+    }
+
+    [Test]
+    public void TestPoolingForMultileConnStringsWithTopologyKeys()
+    {
+        var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Topology Keys=cloud1.datacenter1.rack1:1;Timeout=0;";
+        var connStringBuilder2 = "host=127.0.0.1;database=yugabyte;userid=tester;password=abc123;Load Balance Hosts=any;Topology Keys=cloud1.datacenter1.rack1:1;Timeout=0;";
+
+
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        CreateCluster();
+
+        try
+        {
+            NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder1);
+            NpgsqlConnection conn1 = new NpgsqlConnection(connStringBuilder1);
+            NpgsqlConnection conn2 = new NpgsqlConnection(connStringBuilder2);
+            conn.Open();
+            conn.Close();
+            conn1.Open();
+            for (var i = 0; i < 6; i++)
+            {
+                NpgsqlConnection conn3 = new NpgsqlConnection(connStringBuilder1);
+                conn3.Open();
+                conns.Add(conn3);
+            }
+            conn2.Open();
+
+            NpgsqlCommand cmd1 = new NpgsqlCommand("SELECT current_user;", conn1);
+            NpgsqlDataReader reader1 = cmd1.ExecuteReader();
+            while (reader1.Read())
+            {
+                Assert.AreEqual(reader1.GetString(0), "postgres");
+            }
+
+            NpgsqlCommand cmd2 = new NpgsqlCommand("SELECT current_user;", conn2);
+            NpgsqlDataReader reader2 = cmd2.ExecuteReader();
+            while (reader2.Read())
+            {
+                Assert.AreEqual(reader2.GetString(0), "tester");
+            }
+
+            Console.WriteLine("Connections Created");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            DestroyCluster();
+        }
+    }
+
+    [Test]
+    public void TestPoolingForMultileConnStringsMultiThread()
+    {
+        var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Timeout=0;";
+        var connStringBuilder2 = "host=127.0.0.1;database=yugabyte;userid=tester;password=abc123;Load Balance Hosts=any;Timeout=0;";
+
+        List<NpgsqlConnection> conns1 = new List<NpgsqlConnection>();
+        List<NpgsqlConnection> conns2 = new List<NpgsqlConnection>();
+
+        CreateCluster();
+        try
+        {
+            List<Thread> threads = new List<Thread>();
+            List<NpgsqlConnection> conn = new List<NpgsqlConnection>();
+            var numThreads = 5;
+            for (var i = 0; i < numThreads; i++)
+            {
+                Thread thread = new Thread(() => {
+                    var threadConns = CreateConnections(connStringBuilder1, 6); // Each thread uses its own list
+                    lock (conns1)
+                    {
+                        conns1.AddRange(threadConns); // Safely add to the shared list
+                    }
+                });
+                threads.Add(thread);
+            }
+            for (var i = 0; i < numThreads; i++)
+            {
+                Thread thread = new Thread(() => {
+                    var threadConns = CreateConnections(connStringBuilder2, 6); // Each thread uses its own list
+                    lock (conns2)
+                    {
+                        conns2.AddRange(threadConns); // Safely add to the shared list
+                    }
+                });
+                threads.Add(thread);
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Start();
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+            NpgsqlCommand cmd1 = new NpgsqlCommand("SELECT current_user;", conns1[0]);
+            NpgsqlDataReader reader1 = cmd1.ExecuteReader();
+            while (reader1.Read())
+            {
+                Assert.AreEqual(reader1.GetString(0), "postgres");
+            }
+
+            NpgsqlCommand cmd2 = new NpgsqlCommand("SELECT current_user;", conns2[0]);
+            NpgsqlDataReader reader2 = cmd2.ExecuteReader();
+            while (reader2.Read())
+            {
+                Assert.AreEqual(reader2.GetString(0), "tester");
+            }
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+        }
+        finally
+        {
+            DestroyCluster();
+        }
+    }
+    static List<NpgsqlConnection> CreateConnections(string connString, int numConns)
+    {
+        List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
+        try
+        {
+            for (var i = 1; i <= numConns; i++)
+            {
+                NpgsqlConnection conn = new NpgsqlConnection(connString);
+                conn.Open();
+                conns.Add(conn);
+            }
+
+            Console.WriteLine("Connections Created");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failure:" + ex.Message);
+            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
+            return conns;
+        }
+
+        return conns;
+
+    }
+    void CreateCluster()
+    {
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl create --rf 3";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "bin/ysqlsh -c \"CREATE USER tester WITH PASSWORD 'abc123'\"";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        cmd = "bin/ysqlsh -c \"GRANT ALL PRIVILEGES ON DATABASE \"yugabyte\" to tester;\"";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+    }
+
+    void DestroyCluster()
+    {
+        string? _Output = null;
+        string? _Error = null;
+        var cmd = "/bin/yb-ctl destroy";
+        ExecuteShellCommand(cmd, ref _Output, ref _Error );
+    }
+}

--- a/test/Npgsql.Tests/YBPoolingWrapperTests.cs
+++ b/test/Npgsql.Tests/YBPoolingWrapperTests.cs
@@ -8,7 +8,7 @@ namespace YBNpgsql.Tests;
 
 public class YBPoolingWrapperTests : YBTestUtils
 {
-    [Test]
+    [Test, Timeout(60000)]
     public void TestPoolingForMultipleConnStrings()
     {
         var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Timeout=0;";
@@ -64,7 +64,7 @@ public class YBPoolingWrapperTests : YBTestUtils
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public void TestPoolingForMultipleConnStringsWithTopologyKeys()
     {
         var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Topology Keys=cloud1.datacenter1.rack1:1;Timeout=0;";
@@ -120,7 +120,7 @@ public class YBPoolingWrapperTests : YBTestUtils
         }
     }
 
-    [Test]
+    [Test, Timeout(60000)]
     public void TestPoolingForMultipleConnStringsMultiThread()
     {
         var connStringBuilder1 = "host=127.0.0.1;database=yugabyte;userid=postgres;password=postgres;Load Balance Hosts=any;Timeout=0;";
@@ -233,15 +233,19 @@ public class YBPoolingWrapperTests : YBTestUtils
         var cmd = "/bin/yb-ctl create --rf 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
-        Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/ysqlsh -c \"CREATE USER tester WITH PASSWORD 'abc123'\"";
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        System.Threading.Thread.Sleep(5000);
+        cmd = "/bin/ysqlsh -c \\\"CREATE USER tester WITH PASSWORD 'abc123'\\\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
-        Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/ysqlsh -c \"GRANT ALL PRIVILEGES ON DATABASE \"yugabyte\" to tester;\"";
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        cmd = "/bin/ysqlsh -c \\\"GRANT ALL PRIVILEGES ON DATABASE \\\"yugabyte\\\" to tester;\\\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
-        Console.WriteLine("Error:" + _Error);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
     }
 
     void DestroyCluster()
@@ -251,6 +255,7 @@ public class YBPoolingWrapperTests : YBTestUtils
         var cmd = "/bin/yb-ctl destroy";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
-        Console.WriteLine("Error:" + _Error);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
     }
 }

--- a/test/Npgsql.Tests/YBPoolingWrapperTests.cs
+++ b/test/Npgsql.Tests/YBPoolingWrapperTests.cs
@@ -230,6 +230,10 @@ public class YBPoolingWrapperTests : YBTestUtils
     {
         string? _Output = null;
         string? _Error = null;
+        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         var cmd = "/bin/yb-ctl create --rf 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);

--- a/test/Npgsql.Tests/YBPoolingWrapperTests.cs
+++ b/test/Npgsql.Tests/YBPoolingWrapperTests.cs
@@ -18,11 +18,12 @@ public class YBPoolingWrapperTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateCluster();
 
+        NpgsqlConnection conn1 = new NpgsqlConnection(connStringBuilder1);
+        NpgsqlConnection conn2 = new NpgsqlConnection(connStringBuilder2);
+
         try
         {
             NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder1);
-            NpgsqlConnection conn1 = new NpgsqlConnection(connStringBuilder1);
-            NpgsqlConnection conn2 = new NpgsqlConnection(connStringBuilder2);
             conn.Open();
             conn.Close();
             conn1.Open();
@@ -56,6 +57,9 @@ public class YBPoolingWrapperTests : YBTestUtils
             {
                 conn.Close();
             }
+
+            conn1.Close();
+            conn2.Close();
             DestroyCluster();
         }
     }
@@ -70,11 +74,12 @@ public class YBPoolingWrapperTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateCluster();
 
+        NpgsqlConnection conn1 = new NpgsqlConnection(connStringBuilder1);
+        NpgsqlConnection conn2 = new NpgsqlConnection(connStringBuilder2);
+
         try
         {
             NpgsqlConnection conn = new NpgsqlConnection(connStringBuilder1);
-            NpgsqlConnection conn1 = new NpgsqlConnection(connStringBuilder1);
-            NpgsqlConnection conn2 = new NpgsqlConnection(connStringBuilder2);
             conn.Open();
             conn.Close();
             conn1.Open();
@@ -108,6 +113,9 @@ public class YBPoolingWrapperTests : YBTestUtils
             {
                 conn.Close();
             }
+
+            conn1.Close();
+            conn2.Close();
             DestroyCluster();
         }
     }
@@ -133,7 +141,7 @@ public class YBPoolingWrapperTests : YBTestUtils
                     var threadConns = CreateConnections(connStringBuilder1, 6); // Each thread uses its own list
                     lock (conns1)
                     {
-                        conns1.AddRange(threadConns); // Safely add to the shared list
+                        conns1.AddRange(threadConns);
                     }
                 });
                 threads.Add(thread);
@@ -159,18 +167,25 @@ public class YBPoolingWrapperTests : YBTestUtils
             {
                 thread.Join();
             }
-            NpgsqlCommand cmd1 = new NpgsqlCommand("SELECT current_user;", conns1[0]);
-            NpgsqlDataReader reader1 = cmd1.ExecuteReader();
-            while (reader1.Read())
+
+            foreach (var conn1 in conns1)
             {
-                Assert.AreEqual(reader1.GetString(0), "postgres");
+                NpgsqlCommand cmd1 = new NpgsqlCommand("SELECT current_user;", conn1);
+                NpgsqlDataReader reader1 = cmd1.ExecuteReader();
+                while (reader1.Read())
+                {
+                    Assert.AreEqual("postgres", reader1.GetString(0));
+                }
             }
 
-            NpgsqlCommand cmd2 = new NpgsqlCommand("SELECT current_user;", conns2[0]);
-            NpgsqlDataReader reader2 = cmd2.ExecuteReader();
-            while (reader2.Read())
+            foreach (var conn2 in conns2)
             {
-                Assert.AreEqual(reader2.GetString(0), "tester");
+                NpgsqlCommand cmd2 = new NpgsqlCommand("SELECT current_user;", conn2);
+                NpgsqlDataReader reader2 = cmd2.ExecuteReader();
+                while (reader2.Read())
+                {
+                    Assert.AreEqual("tester",reader2.GetString(0) );
+                }
             }
 
         }
@@ -218,12 +233,15 @@ public class YBPoolingWrapperTests : YBTestUtils
         var cmd = "/bin/yb-ctl create --rf 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
-        cmd = "bin/ysqlsh -c \"CREATE USER tester WITH PASSWORD 'abc123'\"";
+        Console.WriteLine("Error:" + _Error);
+        cmd = "/bin/ysqlsh -c \"CREATE USER tester WITH PASSWORD 'abc123'\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
-        cmd = "bin/ysqlsh -c \"GRANT ALL PRIVILEGES ON DATABASE \"yugabyte\" to tester;\"";
+        Console.WriteLine("Error:" + _Error);
+        cmd = "/bin/ysqlsh -c \"GRANT ALL PRIVILEGES ON DATABASE \"yugabyte\" to tester;\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        Console.WriteLine("Error:" + _Error);
     }
 
     void DestroyCluster()
@@ -232,5 +250,7 @@ public class YBPoolingWrapperTests : YBTestUtils
         string? _Error = null;
         var cmd = "/bin/yb-ctl destroy";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        Console.WriteLine("Error:" + _Error);
     }
 }

--- a/test/Npgsql.Tests/YBPoolingWrapperTests.cs
+++ b/test/Npgsql.Tests/YBPoolingWrapperTests.cs
@@ -50,11 +50,6 @@ public class YBPoolingWrapperTests : YBTestUtils
 
             Console.WriteLine("Connections Created");
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
         finally
         {
             foreach (var conn in conns)
@@ -106,11 +101,6 @@ public class YBPoolingWrapperTests : YBTestUtils
             }
 
             Console.WriteLine("Connections Created");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
         }
         finally
         {
@@ -183,11 +173,6 @@ public class YBPoolingWrapperTests : YBTestUtils
                 Assert.AreEqual(reader2.GetString(0), "tester");
             }
 
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
         }
         finally
         {

--- a/test/Npgsql.Tests/YBPreparedStatementsTest.cs
+++ b/test/Npgsql.Tests/YBPreparedStatementsTest.cs
@@ -1,14 +1,45 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using YBNpgsqlTypes;
 using NUnit.Framework;
 
 namespace YBNpgsql.Tests;
 
-public class YBPreparedStatementsTest
+public class YBPreparedStatementsTest : YBTestUtils
 {
-    [Test]
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        string? _Output = null;
+        string? _Error = null;
+        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+        ExecuteShellCommand("/bin/yb-ctl create --rf 3", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        Thread.Sleep(5000);
 
+        var connStringBuilder = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugabyte";
+        using var conn = new NpgsqlConnection(connStringBuilder);
+        conn.Open();
+        using var cmd = new NpgsqlCommand("CREATE DATABASE northwind", conn);
+        try { cmd.ExecuteNonQuery(); }
+        catch (Exception ex) { Console.WriteLine("northwind DB may already exist: " + ex.Message); }
+    }
+
+    [OneTimeTearDown]
+    public void TearDown()
+    {
+        string? _Output = null;
+        string? _Error = null;
+        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+    }
+
+    [Test]
     public async Task PreparedStatementsTestWithFlagsEnabled()
     {
         var connStringBuilder = "host=localhost;port=5433;database=yugabyte;userid=yugabyte;password=yugabyte;Enable Discard Sequences=false;Enable Discard Temp= false;Enable Close All=false;Load Balance Hosts=true;";
@@ -16,6 +47,8 @@ public class YBPreparedStatementsTest
         try
         {
             conn.Open();
+            using var dropCmd = new NpgsqlCommand("DROP TABLE IF EXISTS employee", conn);
+            dropCmd.ExecuteNonQuery();
             NpgsqlCommand empCreateCmd = new NpgsqlCommand("CREATE TABLE employee (id int PRIMARY KEY,age int);", conn);
             empCreateCmd.ExecuteNonQuery();
             Console.WriteLine("Created table Employee");
@@ -34,16 +67,14 @@ public class YBPreparedStatementsTest
                 await empInsertCommand.ExecuteNonQueryAsync();
             }
 
-            conn.Close();
         }
         finally
         {
-
+            conn.Close();
         }
     }
 
     [Test]
-
     public void TypeLoadingTimeTest()
     {
         var connStringBuilderWithNoTypeLoading = "host=localhost;port=5433;database=northwind;userid=yugabyte;Enable Discard Sequences=false;Enable Discard Temp= false;Load Balance Hosts=true; Server Compatibility Mode=NoTypeLoading";

--- a/test/Npgsql.Tests/YBPreparedStatementsTest.cs
+++ b/test/Npgsql.Tests/YBPreparedStatementsTest.cs
@@ -11,13 +11,8 @@ public class YBPreparedStatementsTest : YBTestUtils
     [OneTimeSetUp]
     public void SetUp()
     {
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-        ExecuteShellCommand("/bin/yb-ctl create --rf 3", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
+        ExecuteShellCommand("/bin/yb-ctl create --rf 3", "create cluster");
         Thread.Sleep(5000);
 
         var connStringBuilder = "host=127.0.0.1;port=5433;database=yugabyte;userid=yugabyte;password=yugabyte";
@@ -31,12 +26,7 @@ public class YBPreparedStatementsTest : YBTestUtils
     [OneTimeTearDown]
     public void TearDown()
     {
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
     }
 
     [Test]

--- a/test/Npgsql.Tests/YBPreparedStatementsTest.cs
+++ b/test/Npgsql.Tests/YBPreparedStatementsTest.cs
@@ -36,9 +36,9 @@ public class YBPreparedStatementsTest
 
             conn.Close();
         }
-        catch (PostgresException e)
+        finally
         {
-            Console.WriteLine(e);
+
         }
     }
 

--- a/test/Npgsql.Tests/YBTestUtils.cs
+++ b/test/Npgsql.Tests/YBTestUtils.cs
@@ -13,6 +13,10 @@ public class YBTestUtils
     public void ExecuteShellCommand(string argument, ref string? _outputMessage, ref string? _errorMessage)
 {
     var path = Environment.GetEnvironmentVariable("YBDB_PATH");
+    if (path == null)
+    {
+        throw new ArgumentException("YBDB_PATH not initialized");
+    }
     var arguments = path + argument;
     // Set process variable
     // Provides access to local and remote processes and enables you to start and stop local system processes.

--- a/test/Npgsql.Tests/YBTestUtils.cs
+++ b/test/Npgsql.Tests/YBTestUtils.cs
@@ -10,55 +10,48 @@ namespace YBNpgsql.Tests;
 
 public class YBTestUtils
 {
-    public void ExecuteShellCommand(string argument, ref string? _outputMessage, ref string? _errorMessage)
-{
-    var path = Environment.GetEnvironmentVariable("YBDB_PATH");
-    if (path == null)
-    {
-        throw new ArgumentException("YBDB_PATH not initialized");
-    }
-    var arguments = path + argument;
-    // Set process variable
-    // Provides access to local and remote processes and enables you to start and stop local system processes.
-    Process? _Process = null;
-    try
-    {
-        ProcessStartInfo startInfo = new ProcessStartInfo()
-        {
-            FileName = "/bin/bash",
-            Arguments = " -c \"" + arguments + " \"",
-            CreateNoWindow = true,
-            RedirectStandardOutput = true,
-            RedirectStandardInput = true,
-            RedirectStandardError = true,
-        };
-        _Process = new Process()
-        {
-            StartInfo = startInfo,
-        };
-        _Process.Start();
+    static readonly string YbdbPath = Environment.GetEnvironmentVariable("YBDB_PATH")
+        ?? throw new ArgumentException("YBDB_PATH not initialized");
 
-        // Instructs the Process component to wait indefinitely for the associated process to exit.
-        _errorMessage = _Process.StandardError.ReadToEnd();
-        _Process.WaitForExit();
+    public void ExecuteShellCommand(string argument, string message)
+    {
+        var arguments = YbdbPath + argument;
+        Process? process = null;
+        try
+        {
+            var startInfo = new ProcessStartInfo()
+            {
+                FileName = "/bin/bash",
+                Arguments = " -c \"" + arguments + " \"",
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardInput = true,
+                RedirectStandardError = true,
+            };
+            process = new Process() { StartInfo = startInfo };
+            Console.WriteLine("Executing command to " + message);
+            process.Start();
 
-        // Instructs the Process component to wait indefinitely for the associated process to exit.
-        _outputMessage = _Process.StandardOutput.ReadToEnd();
-        _Process.WaitForExit();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            Console.WriteLine("Output:" + output);
+            if (!string.IsNullOrWhiteSpace(error))
+                Console.WriteLine("Error:" + error);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Exception caught in process: {0}", ex);
+            throw;
+        }
+        finally
+        {
+            process?.Close();
+            process?.Dispose();
+        }
     }
-    catch (Exception _Exception)
-    {
-        // Error
-        Console.WriteLine("Exception caught in process: {0}", _Exception.ToString());
-    }
-    finally
-    {
-        // close process and do cleanup
-        _Process?.Close();
-        _Process?.Dispose();
-        _Process = null!;
-    }
-}
 
     protected static async Task VerifyOn(string server, int ExpectedCount)
     {

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -23,11 +23,6 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, numConns, 0, 0, 0, 0});
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
         finally
         {
             CloseConnections(conns);
@@ -55,11 +50,6 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, 0, 0, 0});
 
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
         }
         finally
         {
@@ -94,11 +84,6 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             }
 
         }
-        catch (NpgsqlException ex)
-        {
-            if (ex.Message.Equals("No suitable host was found", StringComparison.OrdinalIgnoreCase))
-                Console.WriteLine("Expected Failure:" + ex.Message);
-        }
         finally
         {
             CloseConnections(conns);
@@ -124,11 +109,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, -1, numConns, 0, 0, 0});
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -148,11 +129,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, numConns, 0, 0, 0, 0});
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -177,11 +154,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, -1, numConns, 0, 0, 0});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -222,11 +195,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             conns.Concat(await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, numConns / 3, numConns / 3, numConns / 3}));
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -255,11 +224,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, 0, 0, 0});
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -277,11 +242,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns, 0, 0, 0});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -306,11 +267,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, -1, numConns, 0});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -338,11 +295,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, -1, -1, numConns});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -376,11 +329,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             }
 
         }
-        catch (NpgsqlException ex)
-        {
-            if (ex.Message.Equals("No suitable host was found", StringComparison.OrdinalIgnoreCase))
-                Console.WriteLine("Expected Failure:" + ex.Message);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -399,11 +348,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns, 0, 0});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -428,11 +373,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, -1, numConns, 0});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -460,11 +401,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, -1, -1, numConns});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -503,11 +440,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             conns.Concat(await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, numConns, -1, -1}));
 
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -525,11 +458,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, numConns / 2, 0, numConns / 2, 0, 0});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -557,11 +486,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{0, -1, numConns /2, -1, numConns / 2, 0});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -601,11 +526,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             }
 
         }
-        catch (NpgsqlException ex)
-        {
-            if (ex.Message.Equals("No suitable host was found", StringComparison.OrdinalIgnoreCase))
-                Console.WriteLine("Expected Failure:" + ex.Message);
-        }
+
         finally
         {
             CloseConnections(conns);
@@ -639,11 +560,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns /2 , -1, -1, -1, -1, numConns / 2});
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failure:" + ex.Message);
-            Console.WriteLine("Failure stacktrace: " + ex.StackTrace);
-        }
+
         finally
         {
            CloseConnections(conns);

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -37,18 +37,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop node : 127.0.0.2, 127.0.0.3
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 3", "stop node 3");
 
         try
         {
@@ -69,18 +59,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop node : 127.0.0.2, 127.0.0.3
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 3", "stop node 3");
 
         try
         {
@@ -110,13 +90,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop node : 127.0.0.2
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
 
         try
         {
@@ -158,13 +132,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop node : 127.0.0.2
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
 
         try
         {
@@ -187,36 +155,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         conns = await CreateConnections(connStringBuilder, numConns, new []{0, numConns, 0, 0, 0, 0});
 
         // Stop Node: 127.0.0.1, 127.0.0.2, 127.0.0.3
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 1";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 1", "stop node 1");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 3", "stop node 3");
 
         try
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{-1, -1, -1, numConns / 3, numConns / 3, numConns / 3});
 
             // Start Node 1
-            _Output = null;
-            _Error = null;
-            cmd = "/bin/yb-ctl start_node 1";
-            ExecuteShellCommand(cmd, ref _Output, ref _Error );
-            Console.WriteLine("Output:" + _Output);
-            if (!string.IsNullOrWhiteSpace(_Error))
-                Console.WriteLine("Error:" + _Error);
+            ExecuteShellCommand("/bin/yb-ctl start_node 1", "start node 1");
 
             Thread.Sleep(10000);
             conns.AddRange(await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, numConns / 3, numConns / 3, numConns / 3}));
@@ -237,18 +185,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop node : 127.0.0.2, 127.0.0.3
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 3", "stop node 3");
 
         try
         {
@@ -288,13 +226,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop Node: 127.0.0.4
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
 
         try
         {
@@ -315,18 +247,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop Node: 127.0.0.4, 127.0.0.5
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 5";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
 
         try
         {
@@ -347,18 +269,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop Node: 127.0.0.4, 127.0.0.5
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 5";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
 
         try
         {
@@ -408,13 +320,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop Node: 127.0.0.4
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
 
         try
         {
@@ -435,18 +341,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop Node: 127.0.0.4, 127.0.0.5
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 5";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
 
         try
         {
@@ -470,34 +366,16 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns, 0, 0});
 
         // Stop Node: 127.0.0.4, 127.0.0.5, 127.0.0.6
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 5";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 6";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 6", "stop node 6");
 
         try
         {
             conns = await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, -1, -1, -1});
 
             // Start RR node: 127.0.0.4
-            cmd = "/bin/yb-ctl start_node 4";
-            ExecuteShellCommand(cmd, ref _Output, ref _Error );
-            Console.WriteLine("Output:" + _Output);
-            if (!string.IsNullOrWhiteSpace(_Error))
-                Console.WriteLine("Error:" + _Error);
+            ExecuteShellCommand("/bin/yb-ctl start_node 4", "start node 4");
             Thread.Sleep(15000);
 
             conns.AddRange(await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, numConns, -1, -1}));
@@ -536,18 +414,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop Node: 127.0.0.2, 127.0.0.4
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
 
         try
         {
@@ -568,28 +436,10 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop Node: 127.0.0.2, 127.0.0.3, 127.0.0.4, 127.0.0.5
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 5";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 3", "stop node 3");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
 
         try
         {
@@ -619,28 +469,10 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
         // Stop Node: 127.0.0.2, 127.0.0.3, 127.0.0.4, 127.0.0.5
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl stop_node 2";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 3";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 4";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl stop_node 5";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl stop_node 2", "stop node 2");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 3", "stop node 3");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 4", "stop node 4");
+        ExecuteShellCommand("/bin/yb-ctl stop_node 5", "stop node 5");
 
         try
         {
@@ -691,49 +523,18 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
 
     void CreateRRCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        var cmd = "/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter2.rack1 --tserver_flags placement_uuid=rr";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter3.rack1 --tserver_flags placement_uuid=rr";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
-        cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter4.rack1 --tserver_flags placement_uuid=rr";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
+        ExecuteShellCommand("/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"", "create cluster");
+        ExecuteShellCommand("/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live", "modify placement info");
+        ExecuteShellCommand("/bin/yb-ctl add_node --placement_info cloud1.datacenter2.rack1 --tserver_flags placement_uuid=rr", "add RR node (datacenter2)");
+        ExecuteShellCommand("/bin/yb-ctl add_node --placement_info cloud1.datacenter3.rack1 --tserver_flags placement_uuid=rr", "add RR node (datacenter3)");
+        ExecuteShellCommand("/bin/yb-ctl add_node --placement_info cloud1.datacenter4.rack1 --tserver_flags placement_uuid=rr", "add RR node (datacenter4)");
         System.Threading.Thread.Sleep(5000);
     }
 
     protected void DestroyCluster()
     {
-        string? _Output = null;
-        string? _Error = null;
-        var cmd = "/bin/yb-ctl destroy";
-        ExecuteShellCommand(cmd, ref _Output, ref _Error );
-        Console.WriteLine("Output:" + _Output);
-        if (!string.IsNullOrWhiteSpace(_Error))
-            Console.WriteLine("Error:" + _Error);
+        ExecuteShellCommand("/bin/yb-ctl destroy", "destroy cluster");
     }
 
     void CloseConnections(List<NpgsqlConnection> conns)

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -42,9 +42,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -70,9 +74,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -83,6 +91,10 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
                 conns.Add(conn);
             }
 
+        }
+        catch (NpgsqlException e)
+        {
+            Console.WriteLine("Caught expected exception:" + e.Message);
         }
         finally
         {
@@ -103,6 +115,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -149,6 +163,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -173,12 +189,18 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 1";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -190,6 +212,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             cmd = "/bin/yb-ctl start_node 1";
             ExecuteShellCommand(cmd, ref _Output, ref _Error );
             Console.WriteLine("Output:" + _Output);
+            if (!string.IsNullOrWhiteSpace(_Error))
+                Console.WriteLine("Error:" + _Error);
 
             Thread.Sleep(10000);
             conns.Concat(await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, numConns / 3, numConns / 3, numConns / 3}));
@@ -215,9 +239,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -262,6 +290,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -287,9 +317,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 5";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -315,9 +349,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 5";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -328,6 +366,10 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
                 conns.Add(conn);
             }
 
+        }
+        catch (NpgsqlException e)
+        {
+            Console.WriteLine("Caught expected Exception:" + e.Message);
         }
 
         finally
@@ -368,6 +410,8 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -393,9 +437,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 5";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -421,12 +469,18 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 5";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 6";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -436,6 +490,9 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             cmd = "/bin/yb-ctl start_node 4";
             ExecuteShellCommand(cmd, ref _Output, ref _Error );
             Console.WriteLine("Output:" + _Output);
+            if (!string.IsNullOrWhiteSpace(_Error))
+                Console.WriteLine("Error:" + _Error);
+            Thread.Sleep(15000);
 
             conns.Concat(await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, numConns, -1, -1}));
 
@@ -478,9 +535,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -506,15 +567,23 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 5";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -526,7 +595,10 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
             }
 
         }
-
+        catch (NpgsqlException e)
+        {
+            Console.WriteLine("Caught Expected Exception:" + e.Message);
+        }
         finally
         {
             CloseConnections(conns);
@@ -546,15 +618,23 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl stop_node 2";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 3";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 4";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl stop_node 5";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
 
         try
         {
@@ -610,18 +690,29 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         var cmd = "/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
-        cmd = "/build/latest/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live";
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        cmd = "/bin/yb-admin --master_addresses 127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100 modify_placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 3 live";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter2.rack1 --tserver_flags placement_uuid=rr";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter3.rack1 --tserver_flags placement_uuid=rr";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         cmd = "/bin/yb-ctl add_node --placement_info cloud1.datacenter4.rack1 --tserver_flags placement_uuid=rr";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
+        System.Threading.Thread.Sleep(5000);
     }
 
     protected void DestroyCluster()
@@ -630,6 +721,9 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
         string? _Error = null;
         var cmd = "/bin/yb-ctl destroy";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
     }
 
     void CloseConnections(List<NpgsqlConnection> conns)

--- a/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
+++ b/test/Npgsql.Tests/YBTopologyAwareRRSupportTests.cs
@@ -179,10 +179,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
     [Test, Timeout(60000)]
     public async Task? TestPreferPrimaryAllPrimaryNodesDown()
     {
-        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferprimary;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
+
+        conns = await CreateConnections(connStringBuilder, numConns, new []{0, numConns, 0, 0, 0, 0});
+
         // Stop Node: 127.0.0.1, 127.0.0.2, 127.0.0.3
         string? _Output = null;
         string? _Error = null;
@@ -216,7 +219,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
                 Console.WriteLine("Error:" + _Error);
 
             Thread.Sleep(10000);
-            conns.Concat(await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, numConns / 3, numConns / 3, numConns / 3}));
+            conns.AddRange(await CreateConnections(connStringBuilder, numConns, new []{numConns, -1, -1, numConns / 3, numConns / 3, numConns / 3}));
 
         }
 
@@ -459,10 +462,13 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
     [Test, Timeout(60000)]
     public async Task? TestPreferRRAllRRNodesDown()
     {
-        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0";
+        var connStringBuilder = "host=127.0.0.1;database=yugabyte;userid=yugabyte;password=yugabyte;Load Balance Hosts=preferrr;Topology Keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2;Timeout=0;YB Servers Refresh Interval=10";
 
         List<NpgsqlConnection> conns = new List<NpgsqlConnection>();
         CreateRRCluster();
+
+        conns = await CreateConnections(connStringBuilder, numConns, new []{0, 0, 0, numConns, 0, 0});
+
         // Stop Node: 127.0.0.4, 127.0.0.5, 127.0.0.6
         string? _Output = null;
         string? _Error = null;
@@ -494,7 +500,7 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
                 Console.WriteLine("Error:" + _Error);
             Thread.Sleep(15000);
 
-            conns.Concat(await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, numConns, -1, -1}));
+            conns.AddRange(await CreateConnections(connStringBuilder, numConns, new []{numConns / 3, numConns / 3, numConns / 3, numConns, -1, -1}));
 
         }
 
@@ -687,6 +693,10 @@ public class YBTopologyAwareRRSupportTests : YBTestUtils
     {
         string? _Output = null;
         string? _Error = null;
+        ExecuteShellCommand("/bin/yb-ctl destroy", ref _Output, ref _Error);
+        Console.WriteLine("Output:" + _Output);
+        if (!string.IsNullOrWhiteSpace(_Error))
+            Console.WriteLine("Error:" + _Error);
         var cmd = "/bin/yb-ctl create --rf 3 --placement_info cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1 --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"";
         ExecuteShellCommand(cmd, ref _Output, ref _Error );
         Console.WriteLine("Output:" + _Output);


### PR DESCRIPTION
**Problem statement:**
Since the _pools variable (list of pools. Each pool corresponds to one node) is static, it only has one connectors list per host. These connectors are created with the connection configuration with which each of the pools were created. 
In this case, when the connection string changes, the connector created from previous conn string is given if it is idle.

**Solution:**
Create a wrapper around PoolingDatasource which maintains two new maps, connection string to connectors and connection string to idle connectors map. When an idle connector is available, check the connection string and give a connector corresponding to that. Same with when a connector is to be returned.

**Tests:**
Added Tests in YBPoolingWrapperTests:
- Test with two connection strings, and check user for each connection string
- Same for connection strings with topology keys and Multithreaded
- Performance test App - Driver-Examples [PR](https://github.com/yugabyte/driver-examples/pull/59)
        - With pooling, the average for all iterations (minus the first one) is 0ms for both the upstream and our driver
        -  Without pooling, the average time for all iterations (minus the first one) is 138ms for upstream driver and 147ms for smart driver. 


**Problem statement 2:**
In case of a 6 node cluster where the configuration was :
127.0.0.1 (primary) -> datacenter1
127.0.0.2 (primary), 127.0.0.4(read replica) -> datacenter2
127.0.0.3 (primary), 127.0.0.5(read replica) -> datacenter3
127.0.0.6(read replica) -> datacenter 4

Topology key priority: datacenter2:1, datacenter3:2

In case of prefer primary, when 127.0.0.2 and 127.0.0.3 are down, the connection should go to 127.0.0.1 (last primary node). But instead it was going to 127.0.0.4.

**Solution:**
This was since prioritytopoolindex was a single map with both primary and read replica nodes. So this created an intermittent issue where for priority 1, it could either store 127.0.0.2 or 127.0.0.4. If it stored 127.0.0.1, when betterNodeAvailable was called, it would see the node is down and move on to the next node and the test would pass, but when 127.0.0.4 was stored, it would see that the node is higher up in priority even though it was a read replica node and the connections would go to that node and fail.

The priority map is separated now to primary and RR.


**7f01b635f73dab5342023663bdfdfe16e5f73608**

*Source Code Changes*

- src/Npgsql/ClusterAwareDataSource.cs
  - New _savedConnectionCounts dictionary — a Dictionary<string, int> keyed by host name that preserves connection counts when the pool-to-connection maps are cleared during a Refresh() cycle as well as when a higher priority nodes comes back up.
  - GetLoad() fallback to saved counts — when a host is not found in either poolToNumConnMapPrimary or poolToNumConnMapRR, the method now checks _savedConnectionCounts before returning 0. This ensures the load balancer still sees the correct load for fallback hosts whose pool entries were temporarily removed.
  - UpdateConnectionMap() — handle pools missing from both maps — after a refresh, a pool object may no longer exist in either connection map because the maps were rebuilt with new pool instances. The method now:
    - On increment: re-inserts the pool into the correct map (primary vs. read-replica) by consulting _hostsToNodeTypeMap.
    - On decrement: if the pool isn't in either map, decrements the count in _savedConnectionCounts instead, and removes the entry once it reaches zero.
  - Prevent duplicate entries in unreachable host lists — added Contains() guard before Add() for both unreachableHostsIndices and unreachableHosts in two code paths (primary and round-robin connection loops).

- src/Npgsql/TopologyAwareDataSource.cs
  - Refresh() — save connection counts before clearing maps — before calling Clear() on poolToNumConnMapPrimary and poolToNumConnMapRR, the method now copies each pool's current connection count into _savedConnectionCounts keyed by host name.
  - CreatePool() — restore connection counts for existing hosts — when CreatePool() encounters a host that already has a pool (the flag == 1 / continue path), it now restores the saved connection count from _savedConnectionCounts into the appropriate map (primary or RR) and removes the entry from the saved map.

*Test Changes*

- Cluster setup reliability (6 test files)
  - Added yb-ctl destroy before every yb-ctl create/start in CreateCluster() / CreateRRCluster() across YBClusterAwareRRSupportTests, YBFallBackTopologyExtended, YBFallbackTopolgyTests, YBLoadBalancerTests, YBPoolingWrapperTests, and YBTopologyAwareRRSupportTests. Ensures a clean cluster state even if a previous test run crashed without cleanup.
- YBFallbackTopolgyTests.cs
  - CloseConnections() now calls NpgsqlConnection.ClearAllPools() + 1s sleep after closing connections. With pooling enabled, conn.Close() returns the connection to the pool rather than closing the physical TCP connection; ClearAllPools() forces physical disconnection so rpcz-based verification sees 0.
- YBFallBackTopologyExtended.cs
  - Increased numConnections from 12 to 18; added sleeps after topology changes for refresh to fire; fixed expected counts to match corrected load-balancing behavior; changed checkNodeDownPrimary to public; uses a single-host connection string with save/restore.
- YBTopologyAwareRRSupportTests.cs
  - Fixed connection string: preferrr → preferprimary in TestPreferPrimaryAllPrimaryNodesDown.
  - Both prefer-primary and prefer-RR tests now establish initial connections before stopping nodes to exercise the saved-connection-count mechanism.
  - Fixed conns.Concat(...) → conns.AddRange(...) (LINQ Concat returns a new enumerable without mutating the list, so connections were silently discarded).
  - Added YB Servers Refresh Interval=10 to prefer-RR test.
- YBPreparedStatementsTest.cs
  - Now extends YBTestUtils; added [OneTimeSetUp]/[OneTimeTearDown] for cluster and northwind DB lifecycle; added DROP TABLE IF EXISTS for idempotency.