### PR TITLE
Upgrade OpenTelemetry.Api from 1.7.0 to 1.15.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="OpenTelemetry.API" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.API" Version="1.15.3" />
 
     <!-- Compatibility -->
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />


### PR DESCRIPTION
OpenTelemetry.Api 1.7.0 is flagged by advisory GHSA-g94r-2vxg-569j (CVE-2026-40894, published Apr 23 2026) as having a moderate severity vulnerability for excessive memory allocation in propagation header parsing. This causes NU1902 build failures when warnings are treated as errors, blocking all Npgsql test runs.

Version 1.15.3 contains the fix for this advisory.